### PR TITLE
feat: first pass at complex object type guards

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
             at: ./
       - run:
           name: Build
-          command: npm run build
+          command: npm run only:build
       - persist_to_workspace:
           root: ./
           paths:
@@ -48,10 +48,13 @@ jobs:
           at: ./
       - run:
           name: Unit Tests
-          command: npm run test-ci
+          command: npm run only:test
       - run:
           name: Coverage
-          command: npm run coverage
+          command: npm run only:lCov
+      - run:
+          name: Upload to codecov
+          command: npm run ci:codecov
       - store_test_results:
           path: ./reports
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
           at: ./
       - run:
           name: Unit Tests
-          command: npm test
+          command: npm run test-ci
       - run:
           name: Coverage
           command: npm run coverage

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ Thumbs.db
 
 # nyc test coverage
 .nyc_output
+coverage.lcov

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,9 +1,8 @@
 {
 	"cache": false,
 	"reporter": [
-		"lcov",
-		"html",
-		"text"
+		"text",
+		"html"
 	],
 	"extension": [
 		".ts"

--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ TypeScript library to build typeguards that explain their decisions
 # semantics
 - A true reasonguard will provide no errors and at least one confirmation of what was checked.
 - A false reasonguard will provide at least one error about what failed.
+
+# compatibility
+
+- `isStringLiteral` may not work unless your project uses at least version 3.4 of `typescript`

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test-ci": "NODE_ENV=test nyc mocha ${MOCHA_OPTS}",
     "integration:single": "",
     "lint": "eslint --ext .ts .",
-    "precommit": "npm run lint && npm run build && npm run test",
+    "precommit": "npm run lint && npm test",
     "coverage": "NODE_ENV=test nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "htmlreportview": "npm run htmlreportview:$(bash -c 'echo $OSTYPE')",
     "htmlreportview:linux-gnu": "xdg-open coverage/index.html",

--- a/package.json
+++ b/package.json
@@ -12,11 +12,17 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "NODE_ENV=test nyc mocha ${MOCHA_OPTS}",
+    "pretest": "npm run build",
+    "test": "npm run test-ci",
+    "test-ci": "NODE_ENV=test nyc mocha ${MOCHA_OPTS}",
     "integration:single": "",
     "lint": "eslint --ext .ts .",
     "precommit": "npm run lint && npm run build && npm run test",
-    "coverage": "NODE_ENV=test nyc report --reporter=text-lcov > coverage.lcov && codecov"
+    "coverage": "NODE_ENV=test nyc report --reporter=text-lcov > coverage.lcov && codecov",
+    "htmlreportview": "npm run htmlreportview:$(bash -c 'echo $OSTYPE')",
+    "htmlreportview:linux-gnu": "xdg-open coverage/index.html",
+    "htmlreportview:darwin": "open coverage/index.html",
+    "clean": "rm -rf coverage/ dist/ .nyc_output/"
   },
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@typescript-eslint/eslint-plugin": "^1.7.0",
     "@typescript-eslint/parser": "^1.7.0",
     "chai": "4.2.0",
+    "codecov": "3.4.0",
     "eslint": "^5.16.0",
     "eslint-config-6river": "^2.0.0",
     "husky": "^1.3.1",
@@ -35,8 +36,7 @@
     "mocha-junit-reporter": "1.22.0",
     "nyc": "14.1.0",
     "source-map-support": "0.5.12",
-    "typescript": "^3.4.5",
-    "codecov": "3.4.0"
+    "typescript": "^3.4.5"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -11,17 +11,21 @@
     "David Durschlag <ddurschlag@6river.com>"
   ],
   "scripts": {
-    "build": "tsc",
-    "pretest": "npm run build",
-    "test": "npm run test-ci",
-    "test-ci": "NODE_ENV=test nyc mocha ${MOCHA_OPTS}",
-    "integration:single": "",
     "lint": "eslint --ext .ts .",
-    "precommit": "npm run lint && npm test",
-    "coverage": "NODE_ENV=test nyc report --reporter=text-lcov > coverage.lcov && codecov",
-    "htmlreportview": "npm run htmlreportview:$(bash -c 'echo $OSTYPE')",
-    "htmlreportview:linux-gnu": "xdg-open coverage/index.html",
-    "htmlreportview:darwin": "open coverage/index.html",
+    "only:build": "tsc",
+    "only:test": "NODE_ENV=test nyc mocha ${MOCHA_OPTS}",
+    "only:lCov": "NODE_ENV=test nyc report --reporter=text-lcov > coverage.lcov",
+    "ci:codecov": "codecov",
+    "prebuild": "npm run lint",
+    "build": "npm run only:build",
+    "pretest": "npm run build",
+    "test": "npm run only:test",
+    "precommit": "npm test",
+
+    "htmlcov": "npm run htmlcov:$(bash -c 'echo $OSTYPE')",
+    "htmlcov:linux-gnu": "xdg-open coverage/index.html",
+    "htmlcov:darwin": "open coverage/index.html",
+
     "clean": "rm -rf coverage/ dist/ .nyc_output/"
   },
   "dependencies": {},

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,5 @@ export * from './combinators';
 export * from './instanceGuards';
 export * from './primitiveGuards';
 export * from './propertyGuards';
+export * from './objectGuards';
 export * from './ReasonGuard';

--- a/src/objectGuards.ts
+++ b/src/objectGuards.ts
@@ -1,0 +1,65 @@
+import {ReasonGuard} from './ReasonGuard';
+import {hasProperty} from './propertyGuards';
+import {thenGuard} from './combinators';
+
+type DifferentFields<FROM extends Object, TO extends FROM, K extends keyof TO = keyof TO> = {
+	[P in K]: P extends keyof FROM ? (
+		// this reverse extends check doesn't work if you just look at T[P],
+		// only if you put it in an object
+		{[PP in P]: FROM[PP]} extends {[PP in P]: TO[PP]} ? never : P
+	) : P;
+}[K]
+
+export type PropertyGuards<FROM extends Object, TO extends FROM> = {
+	[P in DifferentFields<FROM, TO>]: P extends keyof FROM ? ReasonGuard<FROM[P], TO[P]> : ReasonGuard<unknown, TO[P]>;
+};
+
+// TODO: there's got to be a better way to write this than as an iife
+// thankfully it's not needed if the exclusion voodoo above works
+// export const identityGuard = (<(<T>() => ReasonGuard<T, T>)>(
+// 	() => (_input, _output, confirmations) => {
+// 		confirmations.push('true');
+// 		return true;
+// 	}
+// ))();
+
+// don't seem to need this
+// type PropertyGuarded<G> = G extends PropertyGuards<infer FROM, infer TO> ? ReasonGuard<FROM, TO> : never;
+
+function checkDefinition<FROM extends Object, TO extends FROM>(
+	definition: PropertyGuards<FROM, TO>, input: FROM, output: Error[], confirmations: string[],
+): input is TO {
+	let anyPassed = false;
+	let anyFailed = false;
+
+	function checkProperty(k: DifferentFields<FROM, TO>) {
+		if (thenGuard(hasProperty(k), definition[k] as any)(input, output, confirmations)) {
+			anyPassed = true;
+		} else {
+			anyFailed = false;
+		}
+	}
+
+	// if k in keyof FROM, then hasProperty is redundant, but that's not something we can express here
+	(Object.getOwnPropertyNames(definition) as (keyof typeof definition)[]).forEach(checkProperty);
+	// repeat!
+	(Object.getOwnPropertySymbols(definition) as (keyof typeof definition)[]).forEach(checkProperty);
+
+	if (!anyPassed && !anyFailed) {
+		try {
+			throw new Error('definition had no guards');
+		} catch (err) {
+			output.push(err);
+			return false;
+		}
+	}
+	return !anyFailed;
+}
+
+// this would save typing, but can't figure out how to use it below (syntax-wise)
+// type PropertyGuardBuilder<FROM, TO extends FROM> = (definition: PropertyGuards<FROM, TO>) => ReasonGuard<FROM, TO>;
+
+export const objectHasDefinition =
+	<(<FROM extends Object, TO extends FROM>(definition: PropertyGuards<FROM, TO>) => ReasonGuard<FROM, TO>)>(
+		(definition) => (input, output, confirmations) => checkDefinition(definition, input, output, confirmations)
+	);

--- a/src/primitiveGuards.ts
+++ b/src/primitiveGuards.ts
@@ -44,9 +44,10 @@ export function isStringLiteral<T extends string, U extends T>(
 			throw new Error(`not in ${keys}`);
 		}
 	});
-	// have to `as any` the literal guard here because `ArrayLiteralCheck<T, typeof keys>` might evaluate to `never`
-	// if it does, the caller is going to end up with a compiler error and so the fact that the typing here went weird
-	// should be a non-issue
+	// have to `unknown` the middle type and `as any` the literal guard here
+	// because `ArrayLiteralCheck<T, typeof keys>` might evaluate to `never`
+	// if it does, the caller is going to end up with a compiler error
+	// and so the fact that the typing here went weird should be moot
 	return thenGuard<unknown, unknown, ArrayLiteralCheck<T, typeof keys>>(isString, litGuard as any);
 };
 

--- a/src/primitiveGuards.ts
+++ b/src/primitiveGuards.ts
@@ -1,4 +1,6 @@
 import {checkerToGuard} from './Checker';
+import {thenGuard} from './combinators';
+import {ReasonGuard} from './ReasonGuard';
 
 type Primitive = 'string'|'number'|'bigint'|'boolean'|'symbol'|'undefined'|'object'|'function';
 // Dangerous -- do not export!
@@ -16,3 +18,15 @@ export const isBoolean = getPrimitiveTypeCheck<boolean>('boolean');
 export const isFunction = getPrimitiveTypeCheck<Function>('function');
 export const isSymbol = getPrimitiveTypeCheck<Symbol>('symbol');
 export const isBigInt = getPrimitiveTypeCheck<BigInt>('bigint');
+
+export function isStringLiteral<T extends string>(keys: {[P in T]: any}): ReasonGuard<unknown, T> {
+	// want this to be computed once when building the guard
+	const values = new Set(Object.getOwnPropertyNames(keys));
+	return thenGuard(isString, checkerToGuard((x: string): string => {
+		if (values.has(x)) {
+			return `is ${x}`;
+		} else {
+			throw new Error(`not in ${[...values.values()]}`);
+		}
+	}));
+};

--- a/src/primitiveGuards.ts
+++ b/src/primitiveGuards.ts
@@ -50,9 +50,3 @@ export function isStringLiteral<T extends string, U extends T>(
 	// and so the fact that the typing here went weird should be moot
 	return thenGuard<unknown, unknown, ArrayLiteralCheck<T, typeof keys>>(isString, litGuard as any);
 };
-
-type _L = 'a' | 'b';
-const k = ['a'] as const;
-type _k = ArrayToLiteral<typeof k>;
-type _kc = LiteralCheck<_L, _k>;
-type _K = ArrayLiteralCheck<_L, typeof k>;

--- a/src/primitiveGuards.ts
+++ b/src/primitiveGuards.ts
@@ -1,6 +1,6 @@
 import {checkerToGuard} from './Checker';
-import {thenGuard} from './combinators';
 import {ReasonGuard} from './ReasonGuard';
+import {orGuard} from './combinators';
 
 type Primitive = 'string'|'number'|'bigint'|'boolean'|'symbol'|'undefined'|'object'|'function';
 // Dangerous -- do not export!
@@ -16,15 +16,25 @@ export const isNumber = getPrimitiveTypeCheck<number>('number');
 export const isString = getPrimitiveTypeCheck<string>('string');
 export const isBoolean = getPrimitiveTypeCheck<boolean>('boolean');
 export const isFunction = getPrimitiveTypeCheck<Function>('function');
-export const isSymbol = getPrimitiveTypeCheck<Symbol>('symbol');
+export const isSymbol = getPrimitiveTypeCheck<symbol>('symbol');
 export const isBigInt = getPrimitiveTypeCheck<BigInt>('bigint');
 
-type StringValuesOf<T> = T extends string ? T : never;
-type ArrayToLiteral<T, K extends keyof T = keyof T> = {[P in K]: StringValuesOf<T[P]>}[K];
-type Boolsy<T extends string> = {[P in T]: boolean};
-type LiteralCheck<T1 extends string, T2 extends string, BAD = unknown> =
-	Boolsy<T1> extends Boolsy<T2> ? (Boolsy<T2> extends Boolsy<T1> ? T1 : BAD) : BAD;
-export type ArrayLiteralCheck<T extends string, TT> = LiteralCheck<T, ArrayToLiteral<TT>>;
+type Literable = string | symbol | number;
+
+type ArrayToLiteral<T> = T extends ReadonlyArray<infer U> ? U : never;
+type BoolMap<T extends Literable> = {[P in T]: boolean};
+type LiteralCheck<T1 extends Literable, T2 extends Literable, BAD = unknown> =
+	BoolMap<T1> extends BoolMap<T2> ? (BoolMap<T2> extends BoolMap<T1> ? T1 : BAD) : BAD;
+export type ArrayLiteralCheck<T extends Literable, TT extends ReadonlyArray<Literable>> =
+	LiteralCheck<T, ArrayToLiteral<TT>>;
+
+export const isLiterable = orGuard<unknown, Literable>(
+	orGuard<unknown, string|symbol>(
+		isString,
+		isSymbol
+	),
+	isNumber
+);
 
 /**
  * Check that a value is a string literal type given the list of values.
@@ -32,21 +42,27 @@ export type ArrayLiteralCheck<T extends string, TT> = LiteralCheck<T, ArrayToLit
  *
  * @param keys Values to check
  */
-export function isStringLiteral<T extends string, U extends T>(
-	keys: ReadonlyArray<U>
+export function isLiteral<T extends Literable, U extends T>(
+	keys: ReadonlyArray<U>,
+	literableGuard: ReasonGuard<unknown, Literable> = isLiterable
 ): ReasonGuard<unknown, ArrayLiteralCheck<T, typeof keys>> {
 	// want this to be computed once when building the guard
-	const values = new Set<string>(keys);
-	const litGuard = checkerToGuard((x: string): string => {
-		if (values.has(x)) {
-			return `is ${x}`;
-		} else {
-			throw new Error(`not in ${keys}`);
+	const values = new Set<Literable>(keys);
+
+	return (input, es, cs): input is ArrayLiteralCheck<T, typeof keys> => {
+		try {
+			if (!literableGuard(input, es, cs)) {
+				return false;
+			}
+			if (values.has(input)) {
+				cs.push(`is ${String(input)}`);
+				return true;
+			} else {
+				throw new Error(`not in ${keys}`);
+			}
+		} catch (err) {
+			es.push(err);
+			return false;
 		}
-	});
-	// have to `unknown` the middle type and `as any` the literal guard here
-	// because `ArrayLiteralCheck<T, typeof keys>` might evaluate to `never`
-	// if it does, the caller is going to end up with a compiler error
-	// and so the fact that the typing here went weird should be moot
-	return thenGuard<unknown, unknown, ArrayLiteralCheck<T, typeof keys>>(isString, litGuard as any);
+	};
 };

--- a/src/primitiveGuards.ts
+++ b/src/primitiveGuards.ts
@@ -38,7 +38,6 @@ export const isLiterable = orGuard<unknown, Literable>(
 
 /**
  * Check that a value is a string literal type given the list of values.
- * CAUTION: this will NOT protect you from forgetting to list all the values of `T` in the parameter!
  *
  * @param keys Values to check
  */

--- a/src/primitiveGuards.ts
+++ b/src/primitiveGuards.ts
@@ -19,14 +19,20 @@ export const isFunction = getPrimitiveTypeCheck<Function>('function');
 export const isSymbol = getPrimitiveTypeCheck<Symbol>('symbol');
 export const isBigInt = getPrimitiveTypeCheck<BigInt>('bigint');
 
-export function isStringLiteral<T extends string>(keys: {[P in T]: any}): ReasonGuard<unknown, T> {
+/**
+ * Check that a value is a string literal type given the list of values.
+ * CAUTION: this will NOT protect you from forgetting to list all the values of `T` in the parameter!
+ *
+ * @param keys Values to check
+ */
+export function isStringLiteral<T extends string>(...keys: T[]): ReasonGuard<unknown, T> {
 	// want this to be computed once when building the guard
-	const values = new Set(Object.getOwnPropertyNames(keys));
+	const values = new Set<string>(keys);
 	return thenGuard(isString, checkerToGuard((x: string): string => {
 		if (values.has(x)) {
 			return `is ${x}`;
 		} else {
-			throw new Error(`not in ${[...values.values()]}`);
+			throw new Error(`not in ${keys}`);
 		}
 	}));
 };

--- a/src/propertyGuards.ts
+++ b/src/propertyGuards.ts
@@ -14,7 +14,7 @@ export const hasProperty =
 		return `property ${p} is present`;
 	});
 
-const propertyHasType =
+export const propertyHasType =
 	<FROM, TO extends FROM>(itemGuard: ReasonGuard<FROM, TO>) =>
 		<T extends string | number | symbol>(p: T) =>
 			checkerToGuard<{ [P in T]: FROM }, { [P in T]: TO }>((input: { [P in T]: FROM }) => {

--- a/test/combinators.spec.ts
+++ b/test/combinators.spec.ts
@@ -1,4 +1,3 @@
-import 'mocha';
 import {assertGuardConfirmed, assertGuardFailed, falseGuard, trueGuard} from './util';
 import {orGuard, notGuard, andGuard, thenGuard} from '../src/combinators';
 

--- a/test/objectGuards.spec.ts
+++ b/test/objectGuards.spec.ts
@@ -1,0 +1,25 @@
+import { PropertyGuards, objectHasDefinition } from '../src/objectGuards';
+import { isBoolean } from '../src/primitiveGuards';
+
+type _From = {
+	a: string;
+	b: number;
+};
+
+type _To = {
+	a: string;
+	b: number;
+	c: boolean;
+};
+
+type _GT = PropertyGuards<_From, _To>;
+
+// TODO: why does this give an error if you explicitly type it as PropertyGuards<_From, _To>?
+// it works in typescript 3.3.4000
+// it fails in 3.4.1 (next release)
+// I think the
+const _G: _GT = {
+	c: isBoolean,
+};
+
+const _g = objectHasDefinition(_G);

--- a/test/objectGuards.spec.ts
+++ b/test/objectGuards.spec.ts
@@ -81,7 +81,7 @@ describe(objectHasDefinition.name, function() {
 
 	context('simple narrowing', function() {
 		const guard = objectHasDefinition<SimpleBase, SimpleNarrowed>({
-			a: isStringLiteral({foo: true, bar: true}),
+			a: isStringLiteral('foo', 'bar'),
 		});
 
 		testPropertyGoodValues(guard, {a: 'xyzzy'}, 'a', ['foo', 'bar']);

--- a/test/objectGuards.spec.ts
+++ b/test/objectGuards.spec.ts
@@ -1,4 +1,4 @@
-import {ReasonGuard, objectHasDefinition, isString, ChangedFields, isStringLiteral} from '../src';
+import {ReasonGuard, objectHasDefinition, isString, ChangedFields, isStringLiteral, ArrayLiteralCheck} from '../src';
 import {assertGuards} from './assertGuards';
 
 // NOTE: half of the testing here is just making sure this file compiles without errors
@@ -81,7 +81,7 @@ describe(objectHasDefinition.name, function() {
 
 	context('simple narrowing', function() {
 		const guard = objectHasDefinition<SimpleBase, SimpleNarrowed>({
-			a: isStringLiteral('foo', 'bar'),
+			a: isStringLiteral(['foo', 'bar']),
 		});
 
 		testPropertyGoodValues(guard, {a: 'xyzzy'}, 'a', ['foo', 'bar']);

--- a/test/objectGuards.spec.ts
+++ b/test/objectGuards.spec.ts
@@ -27,14 +27,13 @@ type ComplexDerived = {
 	};
 	e: string;
 };
-type ComplexDerived2 = {
-	a: string;
-	b: {
-		c: 'foo' | 'bar';
-		d: string;
-	};
-	e: string;
+
+type OptionalBase = {
+	a?: string;
 };
+type OptionalNarrowed = {
+	a: string;
+}
 
 const commonValues = [0, 'string', false, () => null, new Date(), null, undefined, []];
 
@@ -87,6 +86,14 @@ describe(objectHasDefinition.name, function() {
 
 		testPropertyGoodValues(guard, {a: 'xyzzy'}, 'a', ['foo', 'bar']);
 		testPropertyBadValues(guard, {a: 'xyzzy'}, 'a', Number.NaN);
+	});
+
+	context('optionality narrowing', function() {
+		const guard = objectHasDefinition<OptionalBase, OptionalNarrowed>({
+			a: isString,
+		});
+		testPropertyGoodValues(guard, {}, 'a', ['foo', 'bar']);
+		testPropertyBadValues(guard, {}, 'a', 1);
 	});
 
 	context('complex derivation part 1', function() {

--- a/test/objectGuards.spec.ts
+++ b/test/objectGuards.spec.ts
@@ -1,39 +1,137 @@
-import {objectHasDefinition} from '../src/objectGuards';
-import {isBoolean, isString} from '../src/primitiveGuards';
+import { ReasonGuard, objectHasDefinition, isString, ChangedFields, checkerToGuard, andGuard, Checker, thenGuard } from '../src';
+import { assertGuardFailed, assertGuardConfirmed } from './util';
 
-type _From = {
+// NOTE: half of the testing here is just making sure this file compiles without errors
+
+type SimpleBase = {
 	a: string;
-	b: number;
 };
-
-type _To = {
+type SimpleExtended = {
 	a: string;
-	b: number;
-	c: boolean;
+	b: string;
 };
-
-const _g = objectHasDefinition<_From, _To>({
-	c: isBoolean,
-});
-
-type _FromComplex = {
+type SimpleNarrowed = {
+	a: 'foo' | 'bar';
+}
+type ComplexBase = {
 	a: string;
 	b: {
-		c: number;
+		c: string;
 	};
 };
-type _ToComplex = {
+type ComplexDerived = {
 	a: string;
 	b: {
-		c: number;
-		d: boolean;
+		c: string;
+		d: string;
+	};
+	e: string;
+};
+type ComplexDerived2 = {
+	a: string;
+	b: {
+		c: 'foo' | 'bar';
+		d: string;
 	};
 	e: string;
 };
 
-const _gc = objectHasDefinition<_FromComplex, _ToComplex>({
-	b: objectHasDefinition({
-		d: isBoolean,
-	}),
-	e: isString,
+const commonValues = [0, 'string', false, () => null, new Date(), null, undefined, []];
+// TODO: move this into primitiveGuards as a generally useful thing?
+function isStringLiteral<T extends string>(keys: {[P in T]: any}): ReasonGuard<unknown, T> {
+	// want this to be computed once when building the guard
+	const values = new Set(Object.getOwnPropertyNames(keys));
+	return thenGuard(isString, checkerToGuard((x: string): string => {
+		if (values.has(x)) {
+			return `is ${x}`;
+		} else {
+			throw new Error(`not in ${[...values.values()]}`);
+		}
+	}));
+};
+
+function testPropertyBadValues<FROM, MID extends FROM, TO extends FROM>(
+	guard: ReasonGuard<FROM, TO>,
+	base: FROM | MID,
+	prop: ChangedFields<FROM, TO>,
+	correctIndex: number,
+	values: any[] = commonValues
+) {
+	for (let i = 0; i < values.length; ++i) {
+		if (i !== correctIndex) {
+			it(`fails if ${prop} has bad value ${values[i]}`, function() {
+				assertGuardFailed(guard, {...base, [prop]: values[i]});
+			});
+		}
+	}
+}
+
+function testPropertyGoodValues<FROM, TO extends FROM>(
+	guard: ReasonGuard<FROM, TO>,
+	base: FROM,
+	prop: ChangedFields<FROM, TO>,
+	values: any[]
+) {
+	for (let i = 0; i < values.length; ++i) {
+		it(`passes if ${prop} has good value ${values[i]}`, function() {
+			assertGuardConfirmed(guard, {...base, [prop]: values[i]});
+		});
+	}
+}
+
+describe(objectHasDefinition.name, function() {
+	context('simple extension', function() {
+		const guard = objectHasDefinition<SimpleBase, SimpleExtended>({
+			b: isString,
+		});
+
+		it('detects missing extension property', function() {
+			assertGuardFailed(guard, {a: 'foo'});
+		});
+		testPropertyBadValues(guard, {a: 'foo'}, 'b', 1);
+		testPropertyGoodValues(guard, {a: 'foo'}, 'b', ['foo', 'xyzzy']);
+	});
+
+	context('simple narrowing', function() {
+		const guard = objectHasDefinition<SimpleBase, SimpleNarrowed>({
+			a: isStringLiteral({foo: true, bar: true}),
+		});
+
+		testPropertyGoodValues(guard, {a: 'xyzzy'}, 'a', ['foo', 'bar']);
+		testPropertyBadValues(guard, {a: 'xyzzy'}, 'a', Number.NaN);
+	});
+
+	context('complex derivation part 1', function() {
+		const guard = objectHasDefinition<ComplexBase, ComplexDerived>({
+			b: objectHasDefinition({
+				d: isString,
+			}),
+			e: isString,
+		});
+
+		// TODO: we want to assert on _why_ most of these tests pass/fail
+
+		it('detects missing new property', function() {
+			assertGuardFailed(guard, {a: 'foo', b: {c: 'foo', d: 'foo'}});
+		});
+		// bad values for new property
+		testPropertyBadValues(guard, {a: 'foo', b: {c: 'foo', d: 'foo'}}, 'e', 1);
+		it('detects missing nested property', function() {
+			assertGuardFailed(guard, {a: 'foo', b: {c: 'foo'}, e: 'foo'});
+		});
+		// bad values for nested property
+		testPropertyBadValues(guard, {a: 'foo', b: {c: 'foo'}, e: 'foo'}, 'b', 1,
+			commonValues.map((v) => ({c: 'foo', d: v})));
+
+		it('accepts good values', function() {
+			assertGuardConfirmed(guard, {a: 'foo', b: {c: 'foo', d: 'foo'}, e: 'foo'});
+		});
+	});
+
+	context('weird corner cases', function() {
+		it('detects no-op guards that made it past the type checker', function() {
+			const guard = objectHasDefinition<SimpleBase, SimpleNarrowed>({} as any);
+			assertGuardFailed(guard, {a: 'foo'});
+		});
+	});
 });

--- a/test/objectGuards.spec.ts
+++ b/test/objectGuards.spec.ts
@@ -1,4 +1,4 @@
-import {ReasonGuard, objectHasDefinition, isString, ChangedFields, isStringLiteral, ArrayLiteralCheck} from '../src';
+import {ReasonGuard, objectHasDefinition, isString, ChangedFields, isLiteral, ArrayLiteralCheck} from '../src';
 import {assertGuards} from './assertGuards';
 
 // NOTE: half of the testing here is just making sure this file compiles without errors
@@ -81,7 +81,7 @@ describe(objectHasDefinition.name, function() {
 
 	context('simple narrowing', function() {
 		const guard = objectHasDefinition<SimpleBase, SimpleNarrowed>({
-			a: isStringLiteral(['foo', 'bar']),
+			a: isLiteral(['foo', 'bar']),
 		});
 
 		testPropertyGoodValues(guard, {a: 'xyzzy'}, 'a', ['foo', 'bar']);

--- a/test/objectGuards.spec.ts
+++ b/test/objectGuards.spec.ts
@@ -1,6 +1,5 @@
-import { PropertyGuards, objectHasDefinition } from '../src/objectGuards';
-import { isBoolean, isString } from '../src/primitiveGuards';
-import { hasBooleanProperty, ReasonGuard } from '../src';
+import {objectHasDefinition} from '../src/objectGuards';
+import {isBoolean, isString} from '../src/primitiveGuards';
 
 type _From = {
 	a: string;
@@ -13,15 +12,9 @@ type _To = {
 	c: boolean;
 };
 
-// TODO: why does this give an error if you explicitly type it as PropertyGuards<_From, _To>?
-// it works in typescript 3.3.4000
-// it fails in 3.4.1 (next release)
-// I think the
-const _G: PropertyGuards<_From, _To> = {
+const _g = objectHasDefinition<_From, _To>({
 	c: isBoolean,
-};
-
-const _g = objectHasDefinition(_G);
+});
 
 type _FromComplex = {
 	a: string;
@@ -37,11 +30,10 @@ type _ToComplex = {
 	};
 	e: string;
 };
-const _GC: PropertyGuards<_FromComplex, _ToComplex> = {
-	// TODO: without the cast this doesn't work, it's not smart enough to infer the from[b] instead of unknown
-	// TODO: even with the cast, typescript >= 3.4.1 fails to recognize that 'b' is in the list of different properties
-	b: hasBooleanProperty('d') as ReasonGuard<_FromComplex['b'], _ToComplex['b']>,
-	e: isString,
-}
 
-const _gc = objectHasDefinition(_GC);
+const _gc = objectHasDefinition<_FromComplex, _ToComplex>({
+	b: objectHasDefinition({
+		d: isBoolean,
+	}),
+	e: isString,
+});

--- a/test/objectGuards.spec.ts
+++ b/test/objectGuards.spec.ts
@@ -1,5 +1,5 @@
-import { ReasonGuard, objectHasDefinition, isString, ChangedFields, checkerToGuard, andGuard, Checker, thenGuard } from '../src';
-import { assertGuardFailed, assertGuardConfirmed } from './util';
+import {ReasonGuard, objectHasDefinition, isString, ChangedFields, isStringLiteral} from '../src';
+import {assertGuardFailed, assertGuardConfirmed} from './util';
 
 // NOTE: half of the testing here is just making sure this file compiles without errors
 
@@ -37,18 +37,6 @@ type ComplexDerived2 = {
 };
 
 const commonValues = [0, 'string', false, () => null, new Date(), null, undefined, []];
-// TODO: move this into primitiveGuards as a generally useful thing?
-function isStringLiteral<T extends string>(keys: {[P in T]: any}): ReasonGuard<unknown, T> {
-	// want this to be computed once when building the guard
-	const values = new Set(Object.getOwnPropertyNames(keys));
-	return thenGuard(isString, checkerToGuard((x: string): string => {
-		if (values.has(x)) {
-			return `is ${x}`;
-		} else {
-			throw new Error(`not in ${[...values.values()]}`);
-		}
-	}));
-};
 
 function testPropertyBadValues<FROM, MID extends FROM, TO extends FROM>(
 	guard: ReasonGuard<FROM, TO>,

--- a/test/objectGuards.spec.ts
+++ b/test/objectGuards.spec.ts
@@ -1,5 +1,6 @@
 import { PropertyGuards, objectHasDefinition } from '../src/objectGuards';
-import { isBoolean } from '../src/primitiveGuards';
+import { isBoolean, isString } from '../src/primitiveGuards';
+import { hasBooleanProperty, ReasonGuard } from '../src';
 
 type _From = {
 	a: string;
@@ -12,14 +13,35 @@ type _To = {
 	c: boolean;
 };
 
-type _GT = PropertyGuards<_From, _To>;
-
 // TODO: why does this give an error if you explicitly type it as PropertyGuards<_From, _To>?
 // it works in typescript 3.3.4000
 // it fails in 3.4.1 (next release)
 // I think the
-const _G: _GT = {
+const _G: PropertyGuards<_From, _To> = {
 	c: isBoolean,
 };
 
 const _g = objectHasDefinition(_G);
+
+type _FromComplex = {
+	a: string;
+	b: {
+		c: number;
+	};
+};
+type _ToComplex = {
+	a: string;
+	b: {
+		c: number;
+		d: boolean;
+	};
+	e: string;
+};
+const _GC: PropertyGuards<_FromComplex, _ToComplex> = {
+	// TODO: without the cast this doesn't work, it's not smart enough to infer the from[b] instead of unknown
+	// TODO: even with the cast, typescript >= 3.4.1 fails to recognize that 'b' is in the list of different properties
+	b: hasBooleanProperty('d') as ReasonGuard<_FromComplex['b'], _ToComplex['b']>,
+	e: isString,
+}
+
+const _gc = objectHasDefinition(_GC);

--- a/test/primitiveGuards.spec.ts
+++ b/test/primitiveGuards.spec.ts
@@ -1,4 +1,3 @@
-import 'mocha';
 import {assertGuardConfirmed, assertGuardFailed} from './util';
 import * as primitive from '../src/primitiveGuards';
 

--- a/test/primitiveGuards.spec.ts
+++ b/test/primitiveGuards.spec.ts
@@ -27,4 +27,18 @@ describe('primitive guards', function() {
 			assertGuards(false)(primitive.isString, {});
 		});
 	});
+	context('isLiteral', function() {
+		const testSymbol = Symbol('test');
+		const literalList = ['a', 3, testSymbol];
+		const guard = primitive.isLiteral(literalList);
+		it('guards for things in the literal', function() {
+			assertGuards(true)(guard, 'a');
+			assertGuards(true)(guard, 3);
+			assertGuards(true)(guard, testSymbol);
+		});
+		it('guards against things not in the literal', function() {
+			assertGuards(false)(guard, '3');
+			assertGuards(false)(guard, Symbol('test'));
+		});
+	})
 });

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,9 +1,9 @@
 import {assert} from 'chai';
-import { ReasonGuard, checkerToGuard } from '../src';
+import {ReasonGuard} from '../src';
 
-export function assertGuardConfirmed<FROM, TO extends FROM>(
+export function assertGuardConfirmed<FROM, MID extends FROM, TO extends FROM>(
 	guard: ReasonGuard<FROM, TO>,
-	value: FROM,
+	value: FROM | MID,
 ) {
 	const es: Error[] = [];
 	const cs: string[] = [];
@@ -12,9 +12,9 @@ export function assertGuardConfirmed<FROM, TO extends FROM>(
 	assert.isAtLeast(cs.length, 1, 'no confirmation reason for successful guard');
 }
 
-export function assertGuardFailed<FROM, TO extends FROM>(
+export function assertGuardFailed<FROM, MID extends FROM, TO extends FROM>(
 	guard: ReasonGuard<FROM, TO>,
-	value: FROM,
+	value: FROM | MID,
 ) {
 	const es: Error[] = [];
 	const cs: string[] = [];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
 		"preserveConstEnums": true,
 		"noImplicitReturns": true,
 		"experimentalDecorators": true,
-		"emitDecoratorMetadata": true
+		"emitDecoratorMetadata": true,
+		"incremental": true
 	},
 	"exclude": [
 		"packages/*/node_modules/**",


### PR DESCRIPTION
- [x] ~Has problems: The mapped typing voodoo works with typescript <= 3.3.4000, but fails in >= 3.4.1~
- [x] Needs tests