### PR TITLE
Feat/concision

### DIFF
--- a/src/objectGuards.ts
+++ b/src/objectGuards.ts
@@ -15,51 +15,28 @@ type NarrowedFields<FROM, TO extends FROM, K extends keyof FROM = keyof FROM> = 
  */
 type ExtendedFields<FROM, TO extends FROM> = Exclude<keyof TO, keyof FROM>;
 
-export type NarrowedGuards<FROM extends object, TO extends FROM> = {
-	[P in NarrowedFields<FROM, TO>]: (p: P) => ReasonGuard<Pick<FROM, P>, Pick<TO, P>>
-}
-
-export type ExtendedGuards<FROM, TO extends FROM> = {
-	[P in ExtendedFields<FROM, TO>]: (p: P) => ReasonGuard<unknown, Pick<TO, P>>;
-}
-
-export type PropertyGuards<FROM extends object, TO extends FROM> = NarrowedGuards<FROM, TO> & ExtendedGuards<FROM, TO>;
-
 /**
  * Fields in `TO` that are different (type or presence) in `FROM`
  */
-export type ChangedFields<FROM extends object, TO extends FROM> = keyof PropertyGuards<FROM, TO>;
+export type ChangedFields<FROM extends object, TO extends FROM> = NarrowedFields<FROM, TO>|ExtendedFields<FROM, TO>;
+
+type Beta<FROM extends object, TO extends FROM, P extends ChangedFields<FROM, TO>> =
+	(p: P) => ReasonGuard<Pick<FROM, P&keyof FROM>, Pick<TO, P>>;
+export type PropertyGuards<FROM extends object, TO extends FROM> = {
+	[P in ChangedFields<FROM, TO>]: Beta<FROM, TO, P>;
+}
 
 function checkDefinition<FROM extends object, TO extends FROM>(
 	definition: PropertyGuards<FROM, TO>, input: FROM, output: Error[], confirmations: string[],
 ): input is TO {
 	let anyPassed = false;
 	let anyFailed = false;
-	const narrowHalf: NarrowedGuards<FROM, TO> = definition;
-	const extendHalf: ExtendedGuards<FROM, TO> = definition;
-
-	function checkNarrow<K extends NarrowedFields<FROM, TO>>(k: K) {
-		if (narrowHalf[k](k)(input, output, confirmations)) {
-			anyPassed = true;
-		} else {
-			anyFailed = true;
-		}
-	}
-	function checkExtend<K extends ExtendedFields<FROM, TO>>(k: K) {
-		if (extendHalf[k](k)(input, output, confirmations)) {
-			anyPassed = true;
-		} else {
-			anyFailed = true;
-		}
-	}
 
 	function checkProperty<K extends ChangedFields<FROM, TO>>(k: K) {
-		if (k in input) {
-			const fromKey: NarrowedFields<FROM, TO> = k as any; // Can't prove this to TS :(
-			checkNarrow(fromKey);
+		if (definition[k](k)(input, output, confirmations)) {
+			anyPassed = true;
 		} else {
-			const fromKey: ExtendedFields<FROM, TO> = k as any; // Can't prove this to TS :(
-			checkExtend(fromKey);
+			anyFailed = true;
 		}
 	}
 

--- a/src/objectGuards.ts
+++ b/src/objectGuards.ts
@@ -9,11 +9,11 @@ import {isObject} from './primitiveGuards';
  */
 type NarrowedFields<FROM, TO extends FROM, K extends keyof FROM = keyof FROM> = {
 	[P in K]: FROM[P] extends TO[P] ? never : P;
-}[K] & keyof TO;
+}[K];
 /**
  * Fields in `TO` that don't exist in `FROM`
  */
-type ExtendedFields<FROM, TO extends FROM> = Exclude<keyof TO, keyof FROM> & keyof TO;
+type ExtendedFields<FROM, TO extends FROM> = Exclude<keyof TO, keyof FROM>;
 
 export type NarrowedGuards<FROM extends object, TO extends FROM> = {
 	[P in NarrowedFields<FROM, TO>]: (p: P) => ReasonGuard<Pick<FROM, P>, Pick<TO, P>>
@@ -28,7 +28,7 @@ export type PropertyGuards<FROM extends object, TO extends FROM> = NarrowedGuard
 /**
  * Fields in `TO` that are different (type or presence) in `FROM`
  */
-export type ChangedFields<FROM extends object, TO extends FROM> = keyof PropertyGuards<FROM, TO> & keyof TO;
+export type ChangedFields<FROM extends object, TO extends FROM> = keyof PropertyGuards<FROM, TO>;
 
 function checkDefinition<FROM extends object, TO extends FROM>(
 	definition: PropertyGuards<FROM, TO>, input: FROM, output: Error[], confirmations: string[],

--- a/src/objectGuards.ts
+++ b/src/objectGuards.ts
@@ -20,10 +20,17 @@ type ExtendedFields<FROM, TO extends FROM> = Exclude<keyof TO, keyof FROM>;
  */
 export type ChangedFields<FROM extends object, TO extends FROM> = NarrowedFields<FROM, TO>|ExtendedFields<FROM, TO>;
 
-type Beta<FROM extends object, TO extends FROM, P extends ChangedFields<FROM, TO>> =
+/**
+ * A function from property name to guard on that property
+ */
+type PropertyGuardFactory<FROM extends object, TO extends FROM, P extends ChangedFields<FROM, TO>> =
 	(p: P) => ReasonGuard<Pick<FROM, P&keyof FROM>, Pick<TO, P>>;
+
+/**
+ *	A mapping from property names to factories for guards on those properties
+ */
 export type PropertyGuards<FROM extends object, TO extends FROM> = {
-	[P in ChangedFields<FROM, TO>]: Beta<FROM, TO, P>;
+	[P in ChangedFields<FROM, TO>]: PropertyGuardFactory<FROM, TO, P>;
 }
 
 function checkDefinition<FROM extends object, TO extends FROM>(

--- a/src/propertyGuards.ts
+++ b/src/propertyGuards.ts
@@ -45,69 +45,61 @@ const propertyIsNull =
 		});
 
 export const narrowedProperty =
-<FROM, T extends keyof FROM, TO extends FROM>
-	(p: T, g: ReasonGuard<FROM[T], TO[T]>) =>
+<FROM_PROP_TYPE, TO_PROP_TYPE extends FROM_PROP_TYPE, T extends string | number | symbol>
+	(p: T, g: ReasonGuard<FROM_PROP_TYPE, TO_PROP_TYPE>):
+	NegatableGuard<Record<T, FROM_PROP_TYPE>, Record<T, TO_PROP_TYPE>> =>
 		propertyHasType(g, p);
 
 export const requiredProperty =
-<TO, T extends keyof TO>
-	(p: T, g: ReasonGuard<unknown, TO[T]>): NegatableGuard<unknown, Pick<TO, T>, unknown> =>
-		thenGuard(hasProperty(p), propertyHasType<unknown, T, TO[T], TO>(g, p));
-
-export type OptionalProps<T> = {
-	[Key in keyof T]:
-	Pick<T, Key> extends Partial<Pick<T, Key>>
-	? Partial<Pick<T, Key>> extends Pick<T, Key>
-		? Key
-		: never
-	: never
-};
-
-export type OptionalKeys<T> =
-		OptionalProps<T>[keyof T] & (string|number|symbol);
+<TO_PROP_TYPE, T extends string | number | symbol>
+	(p: T, g: ReasonGuard<unknown, TO_PROP_TYPE>):
+	NegatableGuard<unknown, Record<T, TO_PROP_TYPE>> =>
+		thenGuard(hasProperty(p), propertyHasType(g, p));
 
 export const optionalProperty =
-<TO, T extends OptionalKeys<TO>>
-	(p: T, g: ReasonGuard<unknown, TO[T]>) =>
+<PTYPE, T extends string | number | symbol>
+	(p: T, g: ReasonGuard<unknown, PTYPE>):
+	NegatableGuard<unknown, Partial<Record<T, PTYPE|undefined>>> =>
 		orGuard(
 			notGuard(hasProperty(p)),
 			orGuard(
-				requiredProperty<Record<T, undefined>, T>(p, isUndefined),
+				requiredProperty(p, isUndefined),
 				requiredProperty(p, g)
 			)
 		);
 
 export const strictOptionalProperty =
-<TO, T extends OptionalKeys<TO>>
-	(p: T, g: ReasonGuard<unknown, TO[T]>) =>
+<PTYPE, T extends string | number | symbol>
+	(p: T, g: ReasonGuard<unknown, PTYPE>):
+	NegatableGuard<unknown, Partial<Record<T, PTYPE>>> =>
 		orGuard(
 			notGuard(hasProperty(p)),
 			requiredProperty(p, g)
 		);
 
 export const hasNumberProperty =
-<T extends string | number | symbol>(p: T): NegatableGuard<unknown, Record<T, number>, unknown> =>
+<T extends string | number | symbol>(p: T): NegatableGuard<unknown, Record<T, number>> =>
 		thenGuard(hasProperty(p), propertyHasType(isNumber, p));
 export const hasStringProperty =
-<T extends string | number | symbol>(p: T): NegatableGuard<unknown, Record<T, string>, unknown> =>
+<T extends string | number | symbol>(p: T): NegatableGuard<unknown, Record<T, string>> =>
 		thenGuard(hasProperty(p), propertyHasType(isString, p));
 export const hasBooleanProperty =
-<T extends string | number | symbol>(p: T): NegatableGuard<unknown, Record<T, boolean>, unknown> =>
+<T extends string | number | symbol>(p: T): NegatableGuard<unknown, Record<T, boolean>> =>
 		thenGuard(hasProperty(p), propertyHasType(isBoolean, p));
 export const hasFunctionProperty =
-<T extends string | number | symbol>(p: T): NegatableGuard<unknown, Record<T, Function>, unknown> =>
+<T extends string | number | symbol>(p: T): NegatableGuard<unknown, Record<T, Function>> =>
 		thenGuard(hasProperty(p), propertyHasType(isFunction, p));
 export const hasDateProperty =
-<T extends string | number | symbol>(p: T): NegatableGuard<unknown, Record<T, Date>, unknown> =>
+<T extends string | number | symbol>(p: T): NegatableGuard<unknown, Record<T, Date>> =>
 		thenGuard(hasProperty(p), propertyHasType(isDate, p));
 export const hasUndefinedProperty =
-<T extends string | number | symbol>(p: T): NegatableGuard<unknown, Record<T, undefined>, unknown> =>
+<T extends string | number | symbol>(p: T): NegatableGuard<unknown, Record<T, undefined>> =>
 		thenGuard(hasProperty(p), propertyIsUndefined(p));
 export const hasNullProperty =
-<T extends string | number | symbol>(p: T): NegatableGuard<unknown, Record<T, null>, unknown> =>
+<T extends string | number | symbol>(p: T): NegatableGuard<unknown, Record<T, null>> =>
 		thenGuard(hasProperty(p), propertyIsNull(p));
 export const hasArrayProperty =
 <T extends string | number | symbol, TO>
 	(itemGuard: ReasonGuard<unknown, TO>) =>
-		(p: T): NegatableGuard<unknown, Record<T, TO[]>, unknown> =>
+		(p: T): NegatableGuard<unknown, Record<T, TO[]>> =>
 			thenGuard(hasProperty(p), propertyHasType(isArrayOfType(itemGuard), p));

--- a/test/examples/geographic-coordinates.spec.ts
+++ b/test/examples/geographic-coordinates.spec.ts
@@ -12,26 +12,26 @@ type GeoCoords = {lat: Lat, lng: Lng};
 const lat = thenGuard(
 	isObject,
 	objectHasDefinition<{}, Lat>({
-		degrees: requiredProperty('degrees', degLat),
-		minutes: requiredProperty('minutes', minSec),
-		seconds: requiredProperty('seconds', minSec),
-		heading: requiredProperty('heading', isLiteral(['N', 'S'])),
+		degrees: requiredProperty(degLat),
+		minutes: requiredProperty(minSec),
+		seconds: requiredProperty(minSec),
+		heading: requiredProperty(isLiteral(['N', 'S'])),
 	})
 );
 
 const lng = thenGuard(
 	isObject,
 	objectHasDefinition<{}, Lng>({
-		degrees: requiredProperty('degrees', degLng),
-		minutes: requiredProperty('minutes', minSec),
-		seconds: requiredProperty('seconds', minSec),
-		heading: requiredProperty('heading', isLiteral(['E', 'W'])),
+		degrees: requiredProperty(degLng),
+		minutes: requiredProperty(minSec),
+		seconds: requiredProperty(minSec),
+		heading: requiredProperty(isLiteral(['E', 'W'])),
 	})
 );
 
 const geoCoords = objectHasDefinition<{}, GeoCoords>({
-	lat: requiredProperty('lat', lat),
-	lng: requiredProperty('lng', lng),
+	lat: requiredProperty(lat),
+	lng: requiredProperty(lng),
 });
 
 describe('geographic coordinates', function() {

--- a/test/objectGuards.spec.ts
+++ b/test/objectGuards.spec.ts
@@ -162,7 +162,7 @@ describe(objectHasDefinition.name, function() {
 
 	context('complex derivation part 1', function() {
 		const guard = objectHasDefinition<ComplexBase, ComplexDerived>({
-			b: narrowedProperty<ComplexBase, 'b', ComplexDerived>('b', objectHasDefinition({
+			b: narrowedProperty('b', objectHasDefinition({
 				d: requiredProperty('d', isString),
 			})),
 			e: requiredProperty('e', isString),

--- a/test/objectGuards.spec.ts
+++ b/test/objectGuards.spec.ts
@@ -1,11 +1,9 @@
 import {
-	isUndefined,
 	ReasonGuard,
 	objectHasDefinition,
 	isString,
 	ChangedFields,
 	isLiteral,
-	orGuard,
 	requiredProperty,
 	optionalProperty,
 	narrowedProperty,
@@ -146,7 +144,7 @@ describe(objectHasDefinition.name, function() {
 
 	context('optionality accepting', function() {
 		const guard = isObjectWithDefinition<OptionalBase>({
-			a: optionalProperty(orGuard(isString, isUndefined)),
+			a: optionalProperty(isString),
 		});
 		testPropertyGoodValues(guard, {}, 'a', ['foo', undefined]);
 		assertGuards(true)(guard, {});

--- a/test/objectGuards.spec.ts
+++ b/test/objectGuards.spec.ts
@@ -50,7 +50,7 @@ type OptionalNarrowed = {
 
 const commonValues = [0, 'string', false, () => null, new Date(), null, undefined, []];
 
-function testPropertyBadValues<FROM, MID extends FROM, TO extends FROM>(
+function testPropertyBadValues<FROM extends object, MID extends FROM, TO extends FROM>(
 	guard: ReasonGuard<FROM, TO>,
 	base: FROM | MID,
 	prop: ChangedFields<FROM, TO>,
@@ -66,7 +66,7 @@ function testPropertyBadValues<FROM, MID extends FROM, TO extends FROM>(
 	}
 }
 
-function testPropertyGoodValues<FROM, TO extends FROM>(
+function testPropertyGoodValues<FROM extends object, TO extends FROM>(
 	guard: ReasonGuard<FROM, TO>,
 	base: FROM,
 	prop: ChangedFields<FROM, TO>,
@@ -82,13 +82,13 @@ function testPropertyGoodValues<FROM, TO extends FROM>(
 describe(isObjectWithDefinition.name, function() {
 	context('double-optional nesting', function() {
 		const guard = isObjectWithDefinition<{a?: {b?: string}}>({
-			a: optionalProperty('a', isObjectWithDefinition<{b?: string}>({
-				b: optionalProperty('b', isString),
+			a: optionalProperty(isObjectWithDefinition<{b?: string}>({
+				b: optionalProperty(isString),
 			})),
 		});
 		const strictGuard = isObjectWithDefinition<{a?: {b?: string}}>({
-			a: strictOptionalProperty('a', isObjectWithDefinition<{b?: string}>({
-				b: strictOptionalProperty('b', isString),
+			a: strictOptionalProperty(isObjectWithDefinition<{b?: string}>({
+				b: strictOptionalProperty(isString),
 			})),
 		});
 
@@ -125,7 +125,7 @@ describe(isObjectWithDefinition.name, function() {
 describe(objectHasDefinition.name, function() {
 	context('simple extension', function() {
 		const guard = objectHasDefinition<SimpleBase, SimpleExtended>({
-			b: requiredProperty('b', isString),
+			b: requiredProperty(isString),
 		});
 
 		it('detects missing extension property', function() {
@@ -137,7 +137,7 @@ describe(objectHasDefinition.name, function() {
 
 	context('simple narrowing', function() {
 		const guard = objectHasDefinition<SimpleBase, SimpleNarrowed>({
-			a: requiredProperty('a', isLiteral(['foo', 'bar'])),
+			a: requiredProperty(isLiteral(['foo', 'bar'])),
 		});
 
 		testPropertyGoodValues(guard, {a: 'xyzzy'}, 'a', ['foo', 'bar']);
@@ -146,7 +146,7 @@ describe(objectHasDefinition.name, function() {
 
 	context('optionality accepting', function() {
 		const guard = isObjectWithDefinition<OptionalBase>({
-			a: optionalProperty('a', orGuard(isString, isUndefined)),
+			a: optionalProperty(orGuard(isString, isUndefined)),
 		});
 		testPropertyGoodValues(guard, {}, 'a', ['foo', undefined]);
 		assertGuards(true)(guard, {});
@@ -154,7 +154,7 @@ describe(objectHasDefinition.name, function() {
 
 	context('optionality narrowing', function() {
 		const guard = objectHasDefinition<OptionalBase, OptionalNarrowed>({
-			a: requiredProperty('a', isString),
+			a: requiredProperty(isString),
 		});
 		testPropertyGoodValues(guard, {}, 'a', ['foo', 'bar']);
 		testPropertyBadValues(guard, {}, 'a', 1);
@@ -162,10 +162,10 @@ describe(objectHasDefinition.name, function() {
 
 	context('complex derivation part 1', function() {
 		const guard = objectHasDefinition<ComplexBase, ComplexDerived>({
-			b: narrowedProperty('b', objectHasDefinition({
-				d: requiredProperty('d', isString),
+			b: narrowedProperty(objectHasDefinition<{c: string}, {c: string, d: string}>({
+				d: requiredProperty(isString),
 			})),
-			e: requiredProperty('e', isString),
+			e: requiredProperty(isString),
 		});
 
 		// TODO: we want to assert on _why_ most of these tests pass/fail

--- a/test/propertyGuards.spec.ts
+++ b/test/propertyGuards.spec.ts
@@ -16,13 +16,13 @@ class Test extends TestBase {
 describe('property guards', function() {
 	context('required property', function() {
 		it('works normally', function() {
-			const guard = property.requiredProperty('foo', isString);
+			const guard = property.requiredProperty(isString)('foo');
 			assertGuards(true)(guard, {foo: 'foo'});
 			assertGuards(false)(guard, {});
 			assertGuards(false)(guard, {foo: 3});
 		});
 		it('works negated', function() {
-			const guard = notGuard(property.requiredProperty('foo', isString));
+			const guard = notGuard(property.requiredProperty(isString)('foo'));
 			assertGuards(!true)(guard, {foo: 'foo'});
 			assertGuards(!false)(guard, {});
 			assertGuards(!false)(guard, {foo: 3});
@@ -30,21 +30,21 @@ describe('property guards', function() {
 	});
 	context('optional property', function() {
 		it('works normally', function() {
-			const guard = property.optionalProperty('foo', isString);
+			const guard = property.optionalProperty(isString)('foo');
 			assertGuards(true)(guard, {foo: 'foo'});
 			assertGuards(true)(guard, {});
 			assertGuards(false)(guard, {foo: 3});
 		});
 		it('works negated', function() {
-			const guard = notGuard(property.optionalProperty('foo', isString));
+			const guard = notGuard(property.optionalProperty(isString)('foo'));
 			assertGuards(!true)(guard, {foo: 'foo'});
 			assertGuards(!true)(guard, {});
 			assertGuards(!false)(guard, {foo: 3});
 		});
 		it('works nested', function() {
 			const guard = isObjectWithDefinition<{foo?: {bar?: string}}>({
-				foo: property.optionalProperty('foo', isObjectWithDefinition<{bar?: string}>({
-					bar: property.optionalProperty('bar', isString),
+				foo: property.optionalProperty(isObjectWithDefinition<{bar?: string}>({
+					bar: property.optionalProperty(isString),
 				})),
 			});
 			const negaGuard = notGuard(guard);
@@ -62,27 +62,6 @@ describe('property guards', function() {
 			assertGuards(!false)(negaGuard, {foo: null});
 			assertGuards(!false)(negaGuard, null);
 		});
-	});
-	context('number property', function() {
-		testGuardMaker(property.hasNumberProperty, 0);
-	});
-	context('string property', function() {
-		testGuardMaker(property.hasStringProperty, 1);
-	});
-	context('boolean property', function() {
-		testGuardMaker(property.hasBooleanProperty, 2);
-	});
-	context('function property', function() {
-		testGuardMaker(property.hasFunctionProperty, 3);
-	});
-	context('date property', function() {
-		testGuardMaker(property.hasDateProperty, 4);
-	});
-	context('null property', function() {
-		testGuardMaker(property.hasNullProperty, 5);
-	});
-	context('undefined property', function() {
-		testGuardMaker(property.hasUndefinedProperty, 6);
 	});
 	context('array property', function() {
 		// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars

--- a/test/propertyGuards.spec.ts
+++ b/test/propertyGuards.spec.ts
@@ -16,13 +16,13 @@ class Test extends TestBase {
 describe('property guards', function() {
 	context('required property', function() {
 		it('works normally', function() {
-			const guard = property.requiredProperty<{foo: string}, 'foo'>('foo', isString);
+			const guard = property.requiredProperty('foo', isString);
 			assertGuards(true)(guard, {foo: 'foo'});
 			assertGuards(false)(guard, {});
 			assertGuards(false)(guard, {foo: 3});
 		});
 		it('works negated', function() {
-			const guard = notGuard(property.requiredProperty<{foo: string}, 'foo'>('foo', isString));
+			const guard = notGuard(property.requiredProperty('foo', isString));
 			assertGuards(!true)(guard, {foo: 'foo'});
 			assertGuards(!false)(guard, {});
 			assertGuards(!false)(guard, {foo: 3});
@@ -30,13 +30,13 @@ describe('property guards', function() {
 	});
 	context('optional property', function() {
 		it('works normally', function() {
-			const guard = property.optionalProperty<{foo?: string}, 'foo'>('foo', isString);
+			const guard = property.optionalProperty('foo', isString);
 			assertGuards(true)(guard, {foo: 'foo'});
 			assertGuards(true)(guard, {});
 			assertGuards(false)(guard, {foo: 3});
 		});
 		it('works negated', function() {
-			const guard = notGuard(property.optionalProperty<{foo?: string}, 'foo'>('foo', isString));
+			const guard = notGuard(property.optionalProperty('foo', isString));
 			assertGuards(!true)(guard, {foo: 'foo'});
 			assertGuards(!true)(guard, {});
 			assertGuards(!false)(guard, {foo: 3});


### PR DESCRIPTION
This is a breaking change, but it gets rid of the exceedingly annoying requirement to "double-specify" property names. It also exposes a bit of a TS owee that should be fixed with the `not T` feature under development (and, more importantly, the `Closed<T>` type it enables).