### PR TITLE
feat: optional semantic narrowing

### DIFF
--- a/src/objectGuards.ts
+++ b/src/objectGuards.ts
@@ -16,13 +16,6 @@ type NarrowedFields<FROM, TO extends FROM, K extends keyof FROM = keyof FROM> = 
 type ExtendedFields<FROM, TO extends FROM> = Exclude<keyof TO, keyof FROM>;
 
 /**
- * Fields in `FROM` and `TO` that are the same type (but may not have the same semantics!)
- */
-type UnchangedFields<FROM, TO extends FROM, K extends keyof FROM = keyof FROM> = {
-	[P in K]: FROM[P] extends TO[P] ? P : never;
-}[K];
-
-/**
  * Fields in `TO` that are different (type or presence) in `FROM`
  */
 export type ChangedFields<FROM extends object, TO extends FROM> = NarrowedFields<FROM, TO>|ExtendedFields<FROM, TO>;

--- a/src/objectGuards.ts
+++ b/src/objectGuards.ts
@@ -23,11 +23,7 @@ export type ChangedFields<FROM extends object, TO extends FROM> = NarrowedFields
 /**
  * A function from property name to guard on that property
  */
-type PropertyGuardFactory<
-	FROM extends object,
-	TO extends FROM,
-	P extends keyof TO
-> =
+type PropertyGuardFactory<FROM extends object, TO extends FROM, P extends keyof TO> =
 	(p: P) => ReasonGuard<Pick<FROM, P&keyof FROM>, Pick<TO, P>>;
 
 export type RequiredGuards<FROM extends object, TO extends FROM, K extends keyof TO = ChangedFields<FROM, TO>> = {

--- a/src/objectGuards.ts
+++ b/src/objectGuards.ts
@@ -16,6 +16,13 @@ type NarrowedFields<FROM, TO extends FROM, K extends keyof FROM = keyof FROM> = 
 type ExtendedFields<FROM, TO extends FROM> = Exclude<keyof TO, keyof FROM>;
 
 /**
+ * Fields in `FROM` and `TO` that are the same type (but may not have the same semantics!)
+ */
+type UnchangedFields<FROM, TO extends FROM, K extends keyof FROM = keyof FROM> = {
+	[P in K]: FROM[P] extends TO[P] ? P : never;
+}[K];
+
+/**
  * Fields in `TO` that are different (type or presence) in `FROM`
  */
 export type ChangedFields<FROM extends object, TO extends FROM> = NarrowedFields<FROM, TO>|ExtendedFields<FROM, TO>;
@@ -23,15 +30,23 @@ export type ChangedFields<FROM extends object, TO extends FROM> = NarrowedFields
 /**
  * A function from property name to guard on that property
  */
-type PropertyGuardFactory<FROM extends object, TO extends FROM, P extends ChangedFields<FROM, TO>> =
+type PropertyGuardFactory<
+	FROM extends object,
+	TO extends FROM,
+	P extends keyof TO
+> =
 	(p: P) => ReasonGuard<Pick<FROM, P&keyof FROM>, Pick<TO, P>>;
+
+export type RequiredGuards<FROM extends object, TO extends FROM, K extends keyof TO = ChangedFields<FROM, TO>> = {
+	[P in K]: PropertyGuardFactory<FROM, TO, P>
+}
+
+export type OptionalGuards<FROM extends object, TO extends FROM> = Partial<RequiredGuards<FROM, TO, keyof TO>>;
 
 /**
  *	A mapping from property names to factories for guards on those properties
  */
-export type PropertyGuards<FROM extends object, TO extends FROM> = {
-	[P in ChangedFields<FROM, TO>]: PropertyGuardFactory<FROM, TO, P>;
-}
+export type PropertyGuards<FROM extends object, TO extends FROM> = RequiredGuards<FROM, TO> & OptionalGuards<FROM, TO>;
 
 function checkDefinition<FROM extends object, TO extends FROM>(
 	definition: PropertyGuards<FROM, TO>, input: FROM, output: Error[], confirmations: string[],
@@ -39,19 +54,26 @@ function checkDefinition<FROM extends object, TO extends FROM>(
 	let anyPassed = false;
 	let anyFailed = false;
 
-	function checkProperty<K extends ChangedFields<FROM, TO>>(k: K) {
-		if (definition[k](k)(input, output, confirmations)) {
-			anyPassed = true;
-		} else {
-			anyFailed = true;
+	const unifiedDefs: OptionalGuards<FROM, TO> = definition;
+
+	type DefinitionKeys = keyof typeof definition;
+
+	function checkProperty<K extends DefinitionKeys>(k: K) {
+		const propertyDefinition = unifiedDefs[k];
+		if (propertyDefinition) {
+			if (propertyDefinition(k)(input, output, confirmations)) {
+				anyPassed = true;
+			} else {
+				anyFailed = true;
+			}
 		}
 	}
 
 	// if k in keyof FROM, then hasProperty is redundant, but that's not something we can express here
 	// TODO: we could cache these property lists for performance
-	(Object.getOwnPropertyNames(definition) as (keyof typeof definition)[]).forEach(checkProperty);
+	(Object.getOwnPropertyNames(definition) as (DefinitionKeys)[]).forEach(checkProperty);
 	// repeat!
-	(Object.getOwnPropertySymbols(definition) as (keyof typeof definition)[]).forEach(checkProperty);
+	(Object.getOwnPropertySymbols(definition) as (DefinitionKeys)[]).forEach(checkProperty);
 
 	if (!anyPassed && !anyFailed) {
 		try {

--- a/src/objectGuards.ts
+++ b/src/objectGuards.ts
@@ -47,11 +47,12 @@ function checkDefinition<FROM extends object, TO extends FROM>(
 	let anyPassed = false;
 	let anyFailed = false;
 
+	// Here be dragons
+	// While typescript accepts this done in pieces,
+	// it won't accept it as a one-liner.
 	const unifiedDefs: OptionalGuards<FROM, TO> = definition;
 
-	type DefinitionKeys = keyof typeof definition;
-
-	function checkProperty<K extends DefinitionKeys>(k: K) {
+	function checkProperty<K extends keyof TO>(k: K) {
 		const propertyDefinition = unifiedDefs[k];
 		if (propertyDefinition) {
 			if (propertyDefinition(k)(input, output, confirmations)) {
@@ -64,9 +65,9 @@ function checkDefinition<FROM extends object, TO extends FROM>(
 
 	// if k in keyof FROM, then hasProperty is redundant, but that's not something we can express here
 	// TODO: we could cache these property lists for performance
-	(Object.getOwnPropertyNames(definition) as (DefinitionKeys)[]).forEach(checkProperty);
+	(Object.getOwnPropertyNames(definition) as (keyof TO)[]).forEach(checkProperty);
 	// repeat!
-	(Object.getOwnPropertySymbols(definition) as (DefinitionKeys)[]).forEach(checkProperty);
+	(Object.getOwnPropertySymbols(definition) as (keyof TO)[]).forEach(checkProperty);
 
 	if (!anyPassed && !anyFailed) {
 		try {

--- a/test/objectGuards.spec.ts
+++ b/test/objectGuards.spec.ts
@@ -9,6 +9,7 @@ import {
 	narrowedProperty,
 	isObjectWithDefinition,
 	strictOptionalProperty,
+	isNumberString,
 } from '../src';
 import {assertGuards} from './assertGuards';
 
@@ -123,6 +124,33 @@ describe(isObjectWithDefinition.name, function() {
 describe(objectHasDefinition.name, function() {
 	context('simple extension', function() {
 		const guard = objectHasDefinition<SimpleBase, SimpleExtended>({
+			b: requiredProperty(isString),
+		});
+
+		it('detects missing extension property', function() {
+			assertGuards(false)(guard, {a: 'foo'});
+		});
+		testPropertyBadValues(guard, {a: 'foo'}, 'b', 1);
+		testPropertyGoodValues(guard, {a: 'foo'}, 'b', ['foo', 'xyzzy']);
+	});
+
+	context('optional semantic narrowing', function() {
+		const guard = objectHasDefinition<SimpleBase, SimpleExtended>({
+			a: narrowedProperty(isNumberString),
+			b: requiredProperty(isString),
+		});
+
+		it('fails on things with wrong semantics', function() {
+			assertGuards(false)(guard, {a: 'foo', b: 'bar'});
+		});
+		it('succeeds on things with proper semantics', function() {
+			assertGuards(true)(guard, {a: '7', b: 'foo'});
+		});
+	});
+
+	context('explicit choice not to add semantics', function() {
+		const guard = objectHasDefinition<SimpleBase, SimpleExtended>({
+			a: undefined,
 			b: requiredProperty(isString),
 		});
 


### PR DESCRIPTION
When guarding from a superset to a subset with identical property x: X, allow ReasonGuard<X, X> to be used for limiting the range of values of intensional types (e.g. string, number, object)