### PR TITLE
fix: add isStrictEqual guard

### DIFF
--- a/src/restrictingGuards.ts
+++ b/src/restrictingGuards.ts
@@ -118,6 +118,17 @@ export const numberIsSafeInteger = andGuard(
 	interval('>=', Number.MIN_SAFE_INTEGER)(Number.MAX_SAFE_INTEGER, '<=')
 );
 
+export const isStrictEqual = <T>(value: T) => checkerToGuard<unknown, T>((input) => {
+	// have to use String() because of Symbols
+	if (value === input) {
+		return `is exactly ${String(value)}`;
+	} else {
+		throw new Error(`is not exactly ${String(input)}`);
+	}
+});
+
+// You can have boolean literal types, but they don't work with Record<>,
+// and they don't make sense in most contexts, so they are handled separately
 type Literable = string | symbol | number;
 
 type ArrayToLiteral<T> = T extends ReadonlyArray<infer U> ? U : never;

--- a/test/restrictingGuards.spec.ts
+++ b/test/restrictingGuards.spec.ts
@@ -16,6 +16,23 @@ describe('restricting guards', function() {
 			assertGuards(false)(guard, Symbol('test'));
 		});
 	});
+	context('isStrictEqual', function() {
+		const testSymbol = Symbol('test');
+		const valueList = ['a', 5, true, false, testSymbol];
+		const badValuesLists: unknown[][] = [[1, 'b'], [4, 'a'], [false], [true], [Symbol('test'), Symbol('bad')]];
+		const guards = valueList.map((v) => restricting.isStrictEqual(v));
+		it('guards for the exact value', function() {
+			guards.forEach((guard, i) => assertGuards(true)(guard, valueList[i]));
+		});
+		it('guards against other values', function() {
+			guards.forEach((guard, i) => valueList.forEach((badValue, j) => {
+				if (i !== j) {
+					assertGuards(false)(guard, badValue);
+				}
+			}));
+			guards.forEach((guard, i) => badValuesLists[i].forEach((badValue) => assertGuards(false)(guard, badValue)));
+		});
+	});
 	context('numberIsInteger', function() {
 		const guard = restricting.numberIsInteger;
 		it('guards for integers', function() {


### PR DESCRIPTION
esp. for boolean values which can't be used with `isLiteral`

Note that this doesn't work with `Number.NaN` -- use `numberIs` for that special case