### PR TITLE
feat: show context on the errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@
 *.launch
 .settings/
 *.sublime-workspace
-
+.history
 # IDE - VSCode
 .vscode/*
 !.vscode/settings.json

--- a/src/Checker.ts
+++ b/src/Checker.ts
@@ -1,5 +1,6 @@
 import {ReasonGuard} from './ReasonGuard';
 import {NegatableGuard, buildNegatable} from './NegatableGuard';
+import {CompositeError} from './ContextError';
 
 export type Checker<FROM> = (input: FROM, context?: PropertyKey[]) => string;
 
@@ -16,8 +17,8 @@ function getRawGuard<FROM, TO extends FROM>(checker: Checker<FROM>): ReasonGuard
 			c.push(checker(input, context));
 			return true;
 		} catch (err) {
-			if (Array.isArray(err)) {
-				e.push(...err);
+			if (err instanceof CompositeError) {
+				e.push(...err.errors);
 			} else {
 				e.push(err);
 			}

--- a/src/Combinators/thenGuard.ts
+++ b/src/Combinators/thenGuard.ts
@@ -15,8 +15,8 @@ function getRawThen<FROM, MID extends FROM, TO extends MID>(
 	left: ReasonGuard<FROM, MID>,
 	right: ReasonGuard<MID, TO>
 ): ReasonGuard<FROM, TO> {
-	return (input, output, confirmations): input is TO => {
-		return left(input, output, confirmations) && right(input, output, confirmations);
+	return (input, output, confirmations, context): input is TO => {
+		return left(input, output, confirmations, context) && right(input, output, confirmations, context);
 	};
 }
 

--- a/src/ContextError.ts
+++ b/src/ContextError.ts
@@ -3,3 +3,9 @@ export class ContextError extends Error {
 		super(message);
 	}
 }
+
+export class CompositeError extends Error {
+	constructor(public readonly errors: ReadonlyArray<Error>) {
+		super(`composite of ${errors.length} error(s)`);
+	}
+}

--- a/src/ContextError.ts
+++ b/src/ContextError.ts
@@ -1,0 +1,5 @@
+export class ContextError extends Error {
+	constructor(message?: string, public readonly context?: ReadonlyArray<PropertyKey>) {
+		super(message);
+	}
+}

--- a/src/ReasonGuard.ts
+++ b/src/ReasonGuard.ts
@@ -2,10 +2,11 @@ export type ReasonGuard<FROM, TO extends FROM> = (
 	input: FROM,
 	output?: Error[],
 	confirmations?: string[],
+	context?: PropertyKey[],
 ) => input is TO;
 
 export const cloneGuard =
 	<FROM, TO extends FROM>
 	(g: ReasonGuard<FROM, TO>): ReasonGuard<FROM, TO> =>
-		(input, es, cs): input is TO =>
-			g(input, es, cs);
+		(input, es, cs, context): input is TO =>
+			g(input, es, cs, context);

--- a/src/arrayHasType.ts
+++ b/src/arrayHasType.ts
@@ -3,7 +3,7 @@ import {checkerToGuard, pushContext} from './Checker';
 import {thenGuard} from './Combinators';
 import {isArray} from './instanceGuards';
 import {NegatableGuard} from './NegatableGuard';
-import {ContextError} from './ContextError';
+import {ContextError, CompositeError} from './ContextError';
 
 export const arrayHasType =
 	<TO>(itemGuard: ReasonGuard<unknown, TO>) =>
@@ -13,9 +13,9 @@ export const arrayHasType =
 				const innerConfs: string[] = [];
 				const innerContext = pushContext(i, context);
 				if (!itemGuard(input[i], innerErrors, innerConfs, innerContext)) {
-					throw innerErrors.map((err) =>
+					throw new CompositeError(innerErrors.map((err) =>
 						new ContextError(`element ${i}: ${err.message}`,
-							err instanceof ContextError ? err.context : innerContext)
+							err instanceof ContextError ? err.context : innerContext))
 					);
 				}
 			}

--- a/src/arrayHasType.ts
+++ b/src/arrayHasType.ts
@@ -1,17 +1,22 @@
 import {ReasonGuard} from './ReasonGuard';
-import {checkerToGuard} from './Checker';
+import {checkerToGuard, pushContext} from './Checker';
 import {thenGuard} from './Combinators';
 import {isArray} from './instanceGuards';
 import {NegatableGuard} from './NegatableGuard';
+import {ContextError} from './ContextError';
 
 export const arrayHasType =
 	<TO>(itemGuard: ReasonGuard<unknown, TO>) =>
-		checkerToGuard<unknown[], TO[]>((input: unknown[]) => {
+		checkerToGuard<unknown[], TO[]>((input: unknown[], context?: PropertyKey[]) => {
 			for (let i = 0; i < input.length; i++) {
 				const innerErrors: Error[] = [];
 				const innerConfs: string[] = [];
-				if (!itemGuard(input[i], innerErrors, innerConfs)) {
-					throw new Error(`element ${i}: ${innerErrors[0].message}`);
+				const innerContext = pushContext(i, context);
+				if (!itemGuard(input[i], innerErrors, innerConfs, innerContext)) {
+					throw innerErrors.map((err) =>
+						new ContextError(`element ${i}: ${err.message}`,
+							err instanceof ContextError ? err.context : innerContext)
+					);
 				}
 			}
 			return `is array of expected type`;

--- a/src/objectGuards.ts
+++ b/src/objectGuards.ts
@@ -38,7 +38,7 @@ export type OptionalGuards<FROM extends object, TO extends FROM> = Partial<Requi
 export type PropertyGuards<FROM extends object, TO extends FROM> = RequiredGuards<FROM, TO> & OptionalGuards<FROM, TO>;
 
 function checkDefinition<FROM extends object, TO extends FROM>(
-	definition: PropertyGuards<FROM, TO>, input: FROM, output: Error[], confirmations: string[],
+	definition: PropertyGuards<FROM, TO>, input: FROM, output: Error[], confirmations: string[], context?: PropertyKey[]
 ): input is TO {
 	let anyPassed = false;
 	let anyFailed = false;
@@ -51,7 +51,7 @@ function checkDefinition<FROM extends object, TO extends FROM>(
 	function checkProperty<K extends keyof TO>(k: K) {
 		const propertyDefinition = unifiedDefs[k];
 		if (propertyDefinition) {
-			if (propertyDefinition(k)(input, output, confirmations)) {
+			if (propertyDefinition(k)(input, output, confirmations, context)) {
 				anyPassed = true;
 			} else {
 				anyFailed = true;
@@ -82,7 +82,8 @@ function checkDefinition<FROM extends object, TO extends FROM>(
 export const objectHasDefinition =
 	<(<FROM extends object, TO extends FROM>(definition: PropertyGuards<FROM, TO>) => ReasonGuard<FROM, TO>)>(
 		(definition) =>
-			(input, output = [], confirmations = []) => checkDefinition(definition, input, output, confirmations)
+			(input, output = [], confirmations = [], context = []) =>
+				checkDefinition(definition, input, output, confirmations, context)
 	);
 
 export const isObjectWithDefinition =

--- a/test/examples/contextual-errors.spec.ts
+++ b/test/examples/contextual-errors.spec.ts
@@ -1,0 +1,71 @@
+import {assert} from 'chai';
+import {assertGuards} from '../assertGuards';
+import {thenGuard,
+	isObject,
+	requiredProperty,
+	isString,
+	isNumber,
+	hasArrayProperty,
+	isObjectWithDefinition,
+	isLiteral} from '../../src';
+import {ContextError} from '../../src/ContextError';
+
+type Bounds = {x1: number, y1: number, x2: number, y2: number};
+type Feature = {name: string, type: 'aisle' | 'workflowPoint' | 'area', bounds: Bounds};
+type Map = {version: string, name: string, bounds: Bounds, aisles: Feature[]};
+
+const isBounds = isObjectWithDefinition<Bounds>({
+	x1: requiredProperty(isNumber),
+	x2: requiredProperty(isNumber),
+	y1: requiredProperty(isNumber),
+	y2: requiredProperty(isNumber),
+});
+
+const isFeature = isObjectWithDefinition<Feature>({
+	name: requiredProperty(isString),
+	type: requiredProperty(isLiteral(['aisle', 'workflowPoint', 'area'])),
+	bounds: requiredProperty(isBounds),
+});
+
+const mapGuard = thenGuard(
+	isObject,
+	isObjectWithDefinition<Map>({
+		version: requiredProperty(isString),
+		name: requiredProperty(isString),
+		bounds: requiredProperty(isBounds),
+		aisles: hasArrayProperty(isFeature),
+	})
+);
+
+
+describe('guard context', function() {
+	const map: Map = {
+		name: 'xpomem',
+		version: '2.0',
+		bounds: {x1: 0, y1: 0, x2: 100, y2: 100},
+		aisles: [{
+			name: 'S2-A1',
+			type: 'aisle',
+			bounds: {x1: 0, y1: 0, x2: 100, y2: 100},
+		}],
+	};
+
+	it('resolves path for errors', function() {
+		const test = JSON.parse(JSON.stringify(map));
+		(test.version as any) = 77;
+		(test.bounds.x1 as any) = 'BAADF00D';
+		(test.aisles[0].bounds.x1 as any) = 'BAADF00D';
+		(test.aisles[0].type) = 'BAADF00D';
+		delete test.aisles[0].name;
+		assertGuards(false)(mapGuard, test);
+
+		const errors: ContextError[] = [];
+		mapGuard(test, errors, []);
+		assert.lengthOf(errors, 5, `no error reason for failed guard`);
+		assert.deepEqual(errors[0].context, ['version']);
+		assert.deepEqual(errors[1].context, ['bounds', 'x1']);
+		assert.deepEqual(errors[2].context, ['aisles', 0, 'name']);
+		assert.deepEqual(errors[3].context, ['aisles', 0, 'type']);
+		assert.deepEqual(errors[4].context, ['aisles', 0, 'bounds', 'x1']);
+	});
+});

--- a/test/examples/contextual-errors.spec.ts
+++ b/test/examples/contextual-errors.spec.ts
@@ -1,7 +1,6 @@
 import {assert} from 'chai';
 import {assertGuards} from '../assertGuards';
-import {thenGuard,
-	isObject,
+import {
 	requiredProperty,
 	isString,
 	isNumber,
@@ -27,15 +26,12 @@ const isFeature = isObjectWithDefinition<Feature>({
 	bounds: requiredProperty(isBounds),
 });
 
-const mapGuard = thenGuard(
-	isObject,
-	isObjectWithDefinition<Map>({
-		version: requiredProperty(isString),
-		name: requiredProperty(isString),
-		bounds: requiredProperty(isBounds),
-		aisles: hasArrayProperty(isFeature),
-	})
-);
+const mapGuard = isObjectWithDefinition<Map>({
+	version: requiredProperty(isString),
+	name: requiredProperty(isString),
+	bounds: requiredProperty(isBounds),
+	aisles: hasArrayProperty(isFeature),
+});
 
 
 describe('guard context', function() {
@@ -60,8 +56,8 @@ describe('guard context', function() {
 		assertGuards(false)(mapGuard, test);
 
 		const errors: ContextError[] = [];
-		mapGuard(test, errors, []);
-		assert.lengthOf(errors, 5, `no error reason for failed guard`);
+		assert.isFalse(mapGuard(test, errors));
+		assert.lengthOf(errors, 5);
 		assert.deepEqual(errors[0].context, ['version']);
 		assert.deepEqual(errors[1].context, ['bounds', 'x1']);
 		assert.deepEqual(errors[2].context, ['aisles', 0, 'name']);

--- a/test/propertyGuards.spec.ts
+++ b/test/propertyGuards.spec.ts
@@ -78,7 +78,7 @@ describe('property guards', function() {
 });
 
 function testGuardMaker(
-	guardMaker: <T extends string | number | symbol>(p: T) => ReasonGuard<unknown, unknown>, correctIndex: number
+	guardMaker: <T extends PropertyKey>(p: T) => ReasonGuard<unknown, unknown>, correctIndex: number
 ) {
 	it('guards for correct properties', function() {
 		assertGuards(true)(guardMaker('prop'), {prop: values[correctIndex]});


### PR DESCRIPTION
When a guard validation fails, a context is attached to the Error.