### PR TITLE
feat: major performance re-work

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -2,7 +2,7 @@
 	"cache": false,
 	"reporter": ["text", "html"],
 	"extension": [".ts"],
-	"include": ["dist/src/**/*.js"],
+	"include": ["dist/src/**/*.js", "src/**/*.ts"],
 	"exclude": ["**/*.d.ts", "coverage/**", "test/**"],
 	"all": true
 }

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,16 +1,8 @@
 {
 	"cache": false,
-	"reporter": [
-		"text",
-		"html"
-	],
-	"extension": [
-		".ts"
-	],
-	"exclude": [
-		"**/*.d.ts",
-		"coverage/**",
-		"test/**"
-	],
+	"reporter": ["text", "html"],
+	"extension": [".ts"],
+	"include": ["dist/src/**/*.js"],
+	"exclude": ["**/*.d.ts", "coverage/**", "test/**"],
 	"all": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,28 @@
 {
-	// Fix syntax/style problems on save
-	"eslint.autoFixOnSave": true,
-	"eslint.validate": [
-		{"language": "javascript", "autoFix": true},
-		{"language": "typescript", "autoFix": true}
-	],
-	// Use locally installed copy of TypeScript instead of the version that ships with the editor
-	"typescript.tsdk": "node_modules/typescript/lib",
+	"eslint.validate": ["javascript", "typescript"],
 	"editor.codeActionsOnSave": {
 		"source.fixAll.eslint": true
-	}
+	},
+	"eslint.workingDirectories": [{ "mode": "auto" }],
+	"editor.defaultFormatter": "esbenp.prettier-vscode",
+	"editor.formatOnSave": true,
+	"[typescript]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode",
+		"editor.formatOnSave": true
+	},
+	"[typescriptreact]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode",
+		"editor.formatOnSave": true
+	},
+	"[javascript]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode",
+		"editor.formatOnSave": true
+	},
+	"[json]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
+	"[yaml]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
+	"typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,14 +1,16 @@
 {
-	// See https://go.microsoft.com/fwlink/?LinkId=733558
-	// for the documentation about the tasks.json format
 	"version": "2.0.0",
 	"tasks": [
-		// Used in launch.json
 		{
 			"label": "npm build",
 			"type": "npm",
 			"script": "build",
-			"problemMatcher": []
+			// TODO: want matches for eslint & prettier too
+			"problemMatcher": ["$tsc"],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
 		}
 	]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2228,9 +2228,9 @@
       }
     },
     "eslint-config-6river": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-6river/-/eslint-config-6river-6.0.1.tgz",
-      "integrity": "sha512-SZbn8Y/nrShyTdCQdEl4O4+b0XlUWSD2gDTlW2TTBlSQK1bBHssjkHRdtbmyfnDfYXWKX2GdSO8GgsbQV4Rf7Q==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-6river/-/eslint-config-6river-6.0.3.tgz",
+      "integrity": "sha512-hwbQ/ioRBo53weWNvgzQuj0g9WU8vO8pU9m8DqbFXwhUjZdOCDc0CT503RoDkCIXLdBRhRLd7WwmMLh+BND3tA==",
       "dev": true,
       "requires": {
         "eslint-config-google": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@typescript-eslint/parser": "^5.3.0",
     "chai": "4.2.0",
     "eslint": "^8.1.0",
-    "eslint-config-6river": "^6.0.1",
+    "eslint-config-6river": "^6.0.3",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-6river": "^1.0.6",
     "eslint-plugin-import": "^2.25.2",
@@ -56,7 +56,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm test",
+      "pre-commit": "SKIP_SLOW=true npm test",
       "commit-msg": "commitlint -e ${HUSKY_GIT_PARAMS}"
     }
   },

--- a/src/Checker.ts
+++ b/src/Checker.ts
@@ -35,10 +35,10 @@ function getRawGuard<FROM, TO extends FROM>(checker: Checker<FROM>): ReasonGuard
 }
 
 function getRawNegation<FROM, TO extends FROM>(checker: Checker<FROM>): ReasonGuard<FROM, TO> {
-	return (input, errors, confirmations): input is TO => {
+	return (input, errors, confirmations, context = []): input is TO => {
 		let result: string | ErrorLike;
 		try {
-			result = checker(input);
+			result = checker(input, context);
 			if (typeof result === 'string') {
 				errors?.push(errorLike(`negation of: ${result}`));
 				return false;

--- a/src/Checker.ts
+++ b/src/Checker.ts
@@ -1,6 +1,6 @@
 import { CompositeError } from './ContextError';
 import { NegatableGuard, buildNegatable } from './NegatableGuard';
-import { ErrorLike, ReasonGuard } from './ReasonGuard';
+import { errorLike, ErrorLike, ReasonGuard } from './ReasonGuard';
 
 export type Checker<FROM> = (input: FROM, context?: PropertyKey[]) => string | ErrorLike;
 
@@ -40,7 +40,7 @@ function getRawNegation<FROM, TO extends FROM>(checker: Checker<FROM>): ReasonGu
 		try {
 			result = checker(input);
 			if (typeof result === 'string') {
-				errors?.push(new Error(`negation of: ${result}`));
+				errors?.push(errorLike(`negation of: ${result}`));
 				return false;
 			}
 		} catch (err: any) {

--- a/src/Combinators/notGuard.ts
+++ b/src/Combinators/notGuard.ts
@@ -1,5 +1,5 @@
 import { isNegatableGuard, NegatableGuard, buildNegatable } from '../NegatableGuard';
-import { ErrorLike, ReasonGuard } from '../ReasonGuard';
+import { errorLike, ErrorLike, ReasonGuard } from '../ReasonGuard';
 
 export const notGuard = <FROM, TO extends FROM, N extends FROM = FROM>(
 	inner: ReasonGuard<FROM, TO> | NegatableGuard<FROM, TO, N>,
@@ -25,10 +25,10 @@ export function negate<FROM, TO extends FROM, N extends FROM>(
 				innerConfirmations = [];
 			}
 			if (inner(input, innerErrors, innerConfirmations)) {
-				if (!innerConfirmations) {
-					return false;
+				if (innerConfirmations) {
+					errors?.push(errorLike(innerConfirmations[innerConfirmations.length - 1]));
 				}
-				throw new Error(innerConfirmations[innerConfirmations.length - 1]);
+				return false;
 			} else {
 				if (innerErrors) {
 					confirmations?.push(innerErrors[0].message);

--- a/src/ContextError.ts
+++ b/src/ContextError.ts
@@ -1,11 +1,15 @@
-export class ContextError extends Error {
-	constructor(message?: string, public readonly context?: ReadonlyArray<PropertyKey>) {
-		super(message);
-	}
+import { ErrorLike } from './ReasonGuard';
+
+export class ContextError implements ErrorLike {
+	constructor(
+		public readonly message: string,
+		public readonly context?: ReadonlyArray<PropertyKey>,
+	) {}
 }
 
-export class CompositeError extends Error {
-	constructor(public readonly errors: ReadonlyArray<Error>) {
-		super(`composite of ${errors.length} error(s)`);
+export class CompositeError implements ErrorLike {
+	public readonly message;
+	constructor(public readonly errors: ReadonlyArray<ErrorLike>) {
+		this.message = `composite of ${errors.length} error(s)`;
 	}
 }

--- a/src/NegatableGuard.ts
+++ b/src/NegatableGuard.ts
@@ -11,6 +11,7 @@ export const isNegatableGuard = <FROM, TO extends FROM, N extends FROM = FROM>(
 ): input is NegatableGuard<FROM, TO, N> =>
 	typeof input === 'function' && typeof (input as any).negate === 'function';
 
+// TODO: why is this so convoluted?
 export const buildNegatable = <FROM, TO extends FROM, N extends FROM = FROM>(
 	input: () => ReasonGuard<FROM, TO>,
 	negated: () => ReasonGuard<FROM, N>,

--- a/src/ReasonGuard.ts
+++ b/src/ReasonGuard.ts
@@ -1,6 +1,19 @@
+/**
+ * creating real errors is costly, due to capturing the stack trace at
+ * instantiation, so instead capture validation errors as just error-like
+ * objects.
+ */
+export interface ErrorLike {
+	message: string;
+}
+
+export function errorLike(message: string): ErrorLike {
+	return { message };
+}
+
 export type ReasonGuard<FROM, TO extends FROM> = (
 	input: FROM,
-	output?: Error[],
+	output?: ErrorLike[],
 	confirmations?: string[],
 	context?: PropertyKey[],
 ) => input is TO;

--- a/src/arrayHasType.ts
+++ b/src/arrayHasType.ts
@@ -12,7 +12,7 @@ export const arrayHasType = <TO>(itemGuard: ReasonGuard<unknown, TO>) =>
 			const innerConfirmations: string[] = [];
 			const innerContext = pushContext(i, context);
 			if (!itemGuard(input[i], innerErrors, innerConfirmations, innerContext)) {
-				throw new CompositeError(
+				return new CompositeError(
 					innerErrors.map(
 						(err) =>
 							new ContextError(

--- a/src/arrayHasType.ts
+++ b/src/arrayHasType.ts
@@ -2,16 +2,16 @@ import { checkerToGuard, pushContext } from './Checker';
 import { thenGuard } from './Combinators';
 import { ContextError, CompositeError } from './ContextError';
 import { NegatableGuard } from './NegatableGuard';
-import { ReasonGuard } from './ReasonGuard';
+import { ErrorLike, ReasonGuard } from './ReasonGuard';
 import { isArray } from './instanceGuards';
 
 export const arrayHasType = <TO>(itemGuard: ReasonGuard<unknown, TO>) =>
 	checkerToGuard<unknown[], TO[]>((input: unknown[], context?: PropertyKey[]) => {
 		for (let i = 0; i < input.length; i++) {
-			const innerErrors: Error[] = [];
-			const innerConfs: string[] = [];
+			const innerErrors: ErrorLike[] = [];
+			const innerConfirmations: string[] = [];
 			const innerContext = pushContext(i, context);
-			if (!itemGuard(input[i], innerErrors, innerConfs, innerContext)) {
+			if (!itemGuard(input[i], innerErrors, innerConfirmations, innerContext)) {
 				throw new CompositeError(
 					innerErrors.map(
 						(err) =>

--- a/src/constantGuards.ts
+++ b/src/constantGuards.ts
@@ -1,26 +1,28 @@
 import { checkerToGuard } from './Checker';
 import { NegatableGuard } from './NegatableGuard';
-import { ReasonGuard } from './ReasonGuard';
+import { errorLike, ReasonGuard } from './ReasonGuard';
 
 const trueGuard: NegatableGuard<unknown, unknown, never> = checkerToGuard(() => 'true');
 
 const falseGuard: NegatableGuard<unknown, never, unknown> = checkerToGuard(() => {
-	throw new Error('false');
+	return errorLike('false');
 });
 
 export const constantGuards: (result: boolean) => NegatableGuard<unknown, unknown, unknown> = (
 	result: boolean,
 ) => (result ? trueGuard : falseGuard);
 
-const unnegatableTrueGuard: ReasonGuard<unknown, unknown> =
-	// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
-	(input, es = [], cs = []): input is unknown => {
-		cs.push('true');
-		return true;
-	};
+const unnegatableTrueGuard: ReasonGuard<unknown, unknown> = (
+	input,
+	errors,
+	confirmations,
+): input is unknown => {
+	confirmations?.push('true');
+	return true;
+};
 
-const unnegatableFalseGuard: ReasonGuard<unknown, never> = (input, es = []): input is never => {
-	es.push(new Error('false'));
+const unnegatableFalseGuard: ReasonGuard<unknown, never> = (input, errors): input is never => {
+	errors?.push(errorLike('false'));
 	return false;
 };
 

--- a/src/instanceGuards.ts
+++ b/src/instanceGuards.ts
@@ -1,8 +1,9 @@
 import { checkerToGuard } from './Checker';
+import { errorLike } from './ReasonGuard';
 
 export const getInstanceTypeCheck = <INST>(ctor: new (...args: any[]) => INST) =>
 	checkerToGuard<unknown, INST>((input: unknown) => {
-		if (!(input instanceof ctor)) throw new Error(`not a ${ctor.name}`);
+		if (!(input instanceof ctor)) return errorLike(`not a ${ctor.name}`);
 		return `a ${ctor.name}`;
 	});
 

--- a/src/objectGuards.ts
+++ b/src/objectGuards.ts
@@ -94,7 +94,7 @@ export const objectHasDefinition = <
 		definition: PropertyGuards<FROM, TO>,
 	) => ReasonGuard<FROM, TO>
 >((definition) =>
-	(input, output = [], confirmations = [], context = []) =>
+	(input, output, confirmations, context = []) =>
 		checkDefinition(definition, input, output, confirmations, context));
 
 export const isObjectWithDefinition = <TO extends object>(definition: PropertyGuards<object, TO>) =>

--- a/src/objectGuards.ts
+++ b/src/objectGuards.ts
@@ -1,5 +1,5 @@
 import { thenGuard } from './Combinators';
-import { ErrorLike, ReasonGuard } from './ReasonGuard';
+import { errorLike, ErrorLike, ReasonGuard } from './ReasonGuard';
 import { isObject } from './primitiveGuards';
 
 // NOTE: for this one you HAVE to have K as a parameter
@@ -50,8 +50,8 @@ export type PropertyGuards<FROM extends object, TO extends FROM> = RequiredGuard
 function checkDefinition<FROM extends object, TO extends FROM>(
 	definition: PropertyGuards<FROM, TO>,
 	input: FROM,
-	output: ErrorLike[],
-	confirmations: string[],
+	output?: ErrorLike[],
+	confirmations?: string[],
 	context?: PropertyKey[],
 ): input is TO {
 	let anyPassed = false;
@@ -80,12 +80,8 @@ function checkDefinition<FROM extends object, TO extends FROM>(
 	(Object.getOwnPropertySymbols(definition) as (keyof TO)[]).forEach(checkProperty);
 
 	if (!anyPassed && !anyFailed) {
-		try {
-			throw new Error('definition had no guards');
-		} catch (err: any) {
-			output.push(err);
-			return false;
-		}
+		output?.push(errorLike('definition had no guards'));
+		return false;
 	}
 	return !anyFailed;
 }

--- a/src/objectGuards.ts
+++ b/src/objectGuards.ts
@@ -1,5 +1,5 @@
 import { thenGuard } from './Combinators';
-import { ReasonGuard } from './ReasonGuard';
+import { ErrorLike, ReasonGuard } from './ReasonGuard';
 import { isObject } from './primitiveGuards';
 
 // NOTE: for this one you HAVE to have K as a parameter
@@ -50,7 +50,7 @@ export type PropertyGuards<FROM extends object, TO extends FROM> = RequiredGuard
 function checkDefinition<FROM extends object, TO extends FROM>(
 	definition: PropertyGuards<FROM, TO>,
 	input: FROM,
-	output: Error[],
+	output: ErrorLike[],
 	confirmations: string[],
 	context?: PropertyKey[],
 ): input is TO {

--- a/src/parseGuards.ts
+++ b/src/parseGuards.ts
@@ -1,4 +1,5 @@
 import { checkerToGuard } from './Checker';
+import { errorLike } from './ReasonGuard';
 
 /**
  * Would Number.parseFloat parse this input?
@@ -7,7 +8,7 @@ export const isNumberString = checkerToGuard<string, string>((input) => {
 	if (!isNaN(Number.parseFloat(input))) {
 		return 'is Number-string';
 	} else {
-		throw new Error('is not Number-string');
+		return errorLike('is not Number-string');
 	}
 });
 
@@ -18,7 +19,7 @@ export const isDateString = checkerToGuard<string, string>((input) => {
 	if (!isNaN(Date.parse(input))) {
 		return 'is Date-string';
 	} else {
-		throw new Error('is not Date-string');
+		return errorLike('is not Date-string');
 	}
 });
 
@@ -31,6 +32,6 @@ export const isBigIntString = checkerToGuard<string, string>((input) => {
 		BigInt(input);
 		return 'is BigInt-string';
 	} catch (err) {
-		throw new Error('is not BigInt-string');
+		return errorLike('is not BigInt-string');
 	}
 });

--- a/src/primitiveGuards.ts
+++ b/src/primitiveGuards.ts
@@ -1,5 +1,6 @@
 import { checkerToGuard } from './Checker';
 import { andGuard, notGuard } from './Combinators';
+import { errorLike } from './ReasonGuard';
 
 type Primitive =
 	| 'string'
@@ -14,7 +15,7 @@ type Primitive =
 // We cannot guarantee that "x: PRIM" -> "typeof x === 'prim'"!
 function getPrimitiveTypeCheck<PRIM>(prim: Primitive) {
 	return checkerToGuard<unknown, PRIM>((input: unknown) => {
-		if (typeof input !== prim) throw new Error(`not a ${prim}`);
+		if (typeof input !== prim) return errorLike(`not a ${prim}`);
 		return `a ${prim}`;
 	});
 }
@@ -23,13 +24,13 @@ export const isUndefined = checkerToGuard<unknown, undefined>((input) => {
 	if (input === undefined) {
 		return `undefined`;
 	}
-	throw new Error('not undefined');
+	return errorLike('not undefined');
 });
 export const isNull = checkerToGuard<unknown, null>((input) => {
 	if (input === null) {
 		return `null`;
 	}
-	throw new Error('not null');
+	return errorLike('not null');
 });
 
 export const isNumber = getPrimitiveTypeCheck<number>('number');

--- a/src/propertyGuards.ts
+++ b/src/propertyGuards.ts
@@ -2,7 +2,7 @@ import { checkerToGuard, pushContext } from './Checker';
 import { thenGuard, orGuard, notGuard } from './Combinators';
 import { ContextError, CompositeError } from './ContextError';
 import { NegatableGuard } from './NegatableGuard';
-import { ReasonGuard } from './ReasonGuard';
+import { ErrorLike, ReasonGuard } from './ReasonGuard';
 import { isArrayOfType } from './arrayHasType';
 import { isUndefined } from './primitiveGuards';
 
@@ -50,10 +50,10 @@ export const propertyHasType = <
 	p: T,
 ) =>
 	checkerToGuard<Record<T, FROMT>, Pick<TO, T>>((input, context) => {
-		const innerErrors: Error[] = [];
-		const innerConfs: string[] = [];
+		const innerErrors: ErrorLike[] = [];
+		const innerConfirmations: string[] = [];
 		const innerContext = pushContext(p, context);
-		if (!itemGuard(input[p], innerErrors, innerConfs, innerContext)) {
+		if (!itemGuard(input[p], innerErrors, innerConfirmations, innerContext)) {
 			throw new CompositeError(
 				innerErrors.map(
 					(err) =>
@@ -64,7 +64,7 @@ export const propertyHasType = <
 				),
 			);
 		}
-		return `property ${p}: ${innerConfs[0]}`;
+		return `property ${p}: ${innerConfirmations[0]}`;
 	});
 
 export const narrowedProperty =

--- a/src/propertyGuards.ts
+++ b/src/propertyGuards.ts
@@ -32,10 +32,10 @@ export const hasProperty = <T extends PropertyKey>(p: T) =>
 	checkerToGuard<unknown, Record<T, unknown>, Partial<Record<T, never>>>(
 		(input: unknown, context?: PropertyKey[]) => {
 			const x: any = input;
-			// if (x[p] === undefined) throw new Error(`property ${p} is undefined`);
-			// if (x[p] === null) throw new Error(`property ${p} is null`); // is this right?
+			// if (x[p] === undefined) return errorLike(`property ${p} is undefined`);
+			// if (x[p] === null) return errorLike(`property ${p} is null`); // is this right?
 			if (!(p in x))
-				throw new ContextError(`property ${p} is not present`, pushContext(p, context));
+				return new ContextError(`property ${p} is not present`, pushContext(p, context));
 			return `property ${p} is present`;
 		},
 	);
@@ -54,7 +54,7 @@ export const propertyHasType = <
 		const innerConfirmations: string[] = [];
 		const innerContext = pushContext(p, context);
 		if (!itemGuard(input[p], innerErrors, innerConfirmations, innerContext)) {
-			throw new CompositeError(
+			return new CompositeError(
 				innerErrors.map(
 					(err) =>
 						new ContextError(

--- a/test/benchGuards.ts
+++ b/test/benchGuards.ts
@@ -61,7 +61,7 @@ export function assertBenchGuard<FROM, TO extends FROM>(
 			negativeResults[mode].nsPerCall,
 			// negative results should be no more than 50ns+50% slower than positives
 			positiveResults[mode].nsPerCall * 1.5 + 50,
-			`negative result for ${mode} should be within 50%+50ns of positive result`,
+			`negative result for ${mode} should be within 50%+50ns of positive result ${negativeResults[mode].nsPerCall}`,
 		);
 	}
 }

--- a/test/benchGuards.ts
+++ b/test/benchGuards.ts
@@ -80,10 +80,7 @@ function benchOnce<FROM, TO extends FROM>(
 	do {
 		if (duration) {
 			let nextIterations = Math.ceil((TargetDurationMs * iterations) / duration);
-			if (nextIterations > iterations * 10) {
-				// don't let it grow too fast, we may have a low-accuracy measurement
-				nextIterations = iterations * 10;
-			} else if (nextIterations > MaxIterations) {
+			if (nextIterations > MaxIterations) {
 				nextIterations = MaxIterations;
 			}
 			iterations = nextIterations;

--- a/test/benchGuards.ts
+++ b/test/benchGuards.ts
@@ -92,10 +92,12 @@ function benchOnce<FROM, TO extends FROM>(
 		// TODO: use high res timer for this
 		duration = timeOnce(guard, values, iterations, errors, confirmations);
 	} while (duration < MinDurationMs && iterations < MaxIterations);
-	// run it again with the same number of iterations and take the faster of the two
-	const rerunDuration = timeOnce(guard, values, iterations, errors, confirmations);
-	if (rerunDuration < duration) {
-		duration = rerunDuration;
+	// take the best of three, we already have one
+	for (let i = 0; i < 2; ++i) {
+		const rerunDuration = timeOnce(guard, values, iterations, errors, confirmations);
+		if (rerunDuration < duration) {
+			duration = rerunDuration;
+		}
 	}
 	return {
 		nsPerCall: Math.round((duration * 1_000_000) / iterations),

--- a/test/benchGuards.ts
+++ b/test/benchGuards.ts
@@ -1,0 +1,98 @@
+import { assert } from 'chai';
+
+import { ReasonGuard } from '../src';
+
+const MinIterations = 100_000;
+const MinDurationMs = 750;
+const TargetDurationMs = 1_000;
+
+interface GuardBenchResult {
+	nsPerCall: number;
+	iterations: number;
+	duration: number;
+}
+/**
+ * Reports ns per call for each mode
+ */
+export interface GuardBenchResults {
+	baseline: GuardBenchResult;
+	withConfirmations: GuardBenchResult;
+	withErrors: GuardBenchResult;
+	withAll: GuardBenchResult;
+}
+
+export function benchGuard<FROM, TO extends FROM>(
+	guard: ReasonGuard<FROM, TO>,
+	valueGenerator: () => FROM[],
+): GuardBenchResults {
+	// cache generated values to reduce GC overhead
+	const values: FROM[] = [];
+	while (values.length < MinIterations) {
+		values.push(...valueGenerator());
+	}
+	return {
+		baseline: benchOnce(guard, values, valueGenerator, false, false),
+		withErrors: benchOnce(guard, values, valueGenerator, true, false),
+		withConfirmations: benchOnce(guard, values, valueGenerator, false, true),
+		withAll: benchOnce(guard, values, valueGenerator, true, true),
+	};
+}
+
+export function assertBenchGuard<FROM, TO extends FROM>(
+	guard: ReasonGuard<FROM, TO>,
+	goodValueGenerator: () => TO,
+	badValueGenerator: () => FROM,
+) {
+	const positiveResults = benchGuard(guard, () => Array.from({ length: 100 }, goodValueGenerator));
+	// eslint-disable-next-line no-console
+	console.log(positiveResults, 'positive results');
+	const negativeResults = benchGuard(guard, () => Array.from({ length: 100 }, badValueGenerator));
+	// eslint-disable-next-line no-console
+	console.log(negativeResults, 'negative results');
+
+	for (const mode of Object.keys(negativeResults) as (keyof GuardBenchResults)[]) {
+		assert.isAtMost(
+			negativeResults[mode].nsPerCall,
+			// negative results should be no more than 50% slower than positives
+			positiveResults[mode].nsPerCall * 1.5,
+			`negative result for ${mode} should be within 50% of positive result`,
+		);
+	}
+}
+
+function benchOnce<FROM, TO extends FROM>(
+	guard: ReasonGuard<FROM, TO>,
+	values: FROM[],
+	valueGenerator: () => FROM[],
+	withErrors: boolean,
+	withConfirmations: boolean,
+): GuardBenchResult {
+	const errors = withErrors ? [] : undefined;
+	const confirmations = withConfirmations ? [] : undefined;
+	let iterations = MinIterations;
+	let duration = 0;
+	do {
+		if (duration) {
+			iterations = Math.ceil(Math.max(iterations, (TargetDurationMs * iterations) / duration));
+			// console.log(`after ${duration}, next ${iterations}`);
+		}
+		while (values.length < iterations) {
+			values.push(...valueGenerator());
+		}
+		// TODO: use high res timer for this
+		const start = Date.now();
+		for (let i = 0; i < values.length && i < iterations; ++i) {
+			// try to reduce GC overhead by truncating these arrays instead of making
+			// new ones
+			errors?.splice(0);
+			confirmations?.splice(0);
+			guard(values[i], errors, confirmations);
+		}
+		duration = Date.now() - start;
+	} while (duration < MinDurationMs);
+	return {
+		nsPerCall: Math.round((duration * 1_000_000) / iterations),
+		iterations,
+		duration,
+	};
+}

--- a/test/benchGuards.ts
+++ b/test/benchGuards.ts
@@ -40,10 +40,15 @@ export function benchGuard<FROM, TO extends FROM>(
 }
 
 export function assertBenchGuard<FROM, TO extends FROM>(
+	ctx: Mocha.Context,
 	guard: ReasonGuard<FROM, TO>,
 	goodValueGenerator: () => TO,
 	badValueGenerator: () => FROM,
 ) {
+	if (process.env.SKIP_SLOW) {
+		// don't run these slow tests during git commit validation or the like
+		ctx.skip();
+	}
 	const positiveResults = benchGuard(guard, () => Array.from({ length: 100 }, goodValueGenerator));
 	// eslint-disable-next-line no-console
 	console.log(positiveResults, 'positive results');

--- a/test/benchGuards.ts
+++ b/test/benchGuards.ts
@@ -2,10 +2,10 @@ import { assert } from 'chai';
 
 import { ReasonGuard } from '../src';
 
-const MinIterations = 100_000;
+const MinIterations = 10_000;
 const MaxIterations = 100_000_000;
-const MinDurationMs = 750;
-const TargetDurationMs = 1_000;
+const MinDurationMs = 75;
+const TargetDurationMs = 100;
 
 interface GuardBenchResult {
 	nsPerCall: number;
@@ -54,9 +54,9 @@ export function assertBenchGuard<FROM, TO extends FROM>(
 	for (const mode of Object.keys(negativeResults) as (keyof GuardBenchResults)[]) {
 		assert.isAtMost(
 			negativeResults[mode].nsPerCall,
-			// negative results should be no more than 50% slower than positives
-			positiveResults[mode].nsPerCall * 1.5,
-			`negative result for ${mode} should be within 50% of positive result`,
+			// negative results should be no more than 50ns+50% slower than positives
+			positiveResults[mode].nsPerCall * 1.5 + 50,
+			`negative result for ${mode} should be within 50%+50ns of positive result`,
 		);
 	}
 }

--- a/test/benchGuards.ts
+++ b/test/benchGuards.ts
@@ -61,7 +61,7 @@ export function assertBenchGuard<FROM, TO extends FROM>(
 			negativeResults[mode].nsPerCall,
 			// negative results should be no more than 50ns+50% slower than positives
 			positiveResults[mode].nsPerCall * 1.5 + 50,
-			`negative result for ${mode} should be within 50%+50ns of positive result ${negativeResults[mode].nsPerCall}`,
+			`negative result for ${mode} should be within 50%+50ns of positive result ${positiveResults[mode].nsPerCall}`,
 		);
 	}
 }

--- a/test/primitiveGuards.spec.ts
+++ b/test/primitiveGuards.spec.ts
@@ -22,7 +22,7 @@ describe('primitive guards', function () {
 				() => Math.random(),
 				(): unknown => Math.random().toString(),
 			);
-		});
+		}).timeout(10_000);
 	});
 	context('isString', function () {
 		it('guards for strings', function () {
@@ -42,7 +42,7 @@ describe('primitive guards', function () {
 				() => Math.random().toString(),
 				(): unknown => Math.random(),
 			);
-		});
+		}).timeout(10_000);
 	});
 	context('isFunction', function () {
 		it('guards for functions', function () {
@@ -66,7 +66,7 @@ describe('primitive guards', function () {
 				() => Math.random,
 				(): unknown => true,
 			);
-		});
+		}).timeout(10_000);
 	});
 	context('isUndefined', function () {
 		it('guards for undefined', function () {
@@ -86,7 +86,7 @@ describe('primitive guards', function () {
 				() => undefined,
 				(): unknown => true,
 			);
-		});
+		}).timeout(10_000);
 	});
 	context('isNull', function () {
 		it('guards for null', function () {
@@ -106,6 +106,6 @@ describe('primitive guards', function () {
 				() => null,
 				(): unknown => true,
 			);
-		});
+		}).timeout(10_000);
 	});
 });

--- a/test/primitiveGuards.spec.ts
+++ b/test/primitiveGuards.spec.ts
@@ -17,11 +17,12 @@ describe('primitive guards', function () {
 		});
 		it('is fast', function () {
 			assertBenchGuard(
+				this,
 				primitive.isNumber,
 				() => Math.random(),
 				(): unknown => Math.random().toString(),
 			);
-		}).timeout(30_000);
+		});
 	});
 	context('isString', function () {
 		it('guards for strings', function () {
@@ -36,11 +37,12 @@ describe('primitive guards', function () {
 		});
 		it('is fast', function () {
 			assertBenchGuard(
+				this,
 				primitive.isString,
 				() => Math.random().toString(),
 				(): unknown => Math.random(),
 			);
-		}).timeout(30_000);
+		});
 	});
 	context('isFunction', function () {
 		it('guards for functions', function () {
@@ -59,11 +61,12 @@ describe('primitive guards', function () {
 		});
 		it('is fast', function () {
 			assertBenchGuard(
+				this,
 				primitive.isFunction,
 				() => Math.random,
 				(): unknown => true,
 			);
-		}).timeout(30_000);
+		});
 	});
 	context('isUndefined', function () {
 		it('guards for undefined', function () {
@@ -78,11 +81,12 @@ describe('primitive guards', function () {
 		});
 		it('is fast', function () {
 			assertBenchGuard(
+				this,
 				primitive.isUndefined,
 				() => undefined,
 				(): unknown => true,
 			);
-		}).timeout(30_000);
+		});
 	});
 	context('isNull', function () {
 		it('guards for null', function () {
@@ -97,10 +101,11 @@ describe('primitive guards', function () {
 		});
 		it('is fast', function () {
 			assertBenchGuard(
+				this,
 				primitive.isNull,
 				() => null,
 				(): unknown => true,
 			);
-		}).timeout(30_000);
+		});
 	});
 });

--- a/test/primitiveGuards.spec.ts
+++ b/test/primitiveGuards.spec.ts
@@ -1,5 +1,6 @@
 import * as primitive from '../src/primitiveGuards';
 import { assertGuards } from './assertGuards';
+import { assertBenchGuard } from './benchGuards';
 
 describe('primitive guards', function () {
 	context('isNumber', function () {
@@ -14,6 +15,13 @@ describe('primitive guards', function () {
 			assertGuards(false)(primitive.isNumber, null);
 			assertGuards(false)(primitive.isNumber, {});
 		});
+		it('is fast', function () {
+			assertBenchGuard(
+				primitive.isNumber,
+				() => Math.random(),
+				(): unknown => Math.random().toString(),
+			);
+		}).timeout(30_000);
 	});
 	context('isString', function () {
 		it('guards for strings', function () {
@@ -26,6 +34,13 @@ describe('primitive guards', function () {
 			assertGuards(false)(primitive.isString, null);
 			assertGuards(false)(primitive.isString, {});
 		});
+		it('is fast', function () {
+			assertBenchGuard(
+				primitive.isString,
+				() => Math.random().toString(),
+				(): unknown => Math.random(),
+			);
+		}).timeout(30_000);
 	});
 	context('isFunction', function () {
 		it('guards for functions', function () {
@@ -42,6 +57,13 @@ describe('primitive guards', function () {
 			assertGuards(false)(primitive.isFunction, 'string');
 			assertGuards(false)(primitive.isFunction, []);
 		});
+		it('is fast', function () {
+			assertBenchGuard(
+				primitive.isFunction,
+				() => Math.random,
+				(): unknown => true,
+			);
+		}).timeout(30_000);
 	});
 	context('isUndefined', function () {
 		it('guards for undefined', function () {
@@ -54,6 +76,13 @@ describe('primitive guards', function () {
 			assertGuards(false)(primitive.isUndefined, null);
 			assertGuards(false)(primitive.isUndefined, {});
 		});
+		it('is fast', function () {
+			assertBenchGuard(
+				primitive.isUndefined,
+				() => undefined,
+				(): unknown => true,
+			);
+		}).timeout(30_000);
 	});
 	context('isNull', function () {
 		it('guards for null', function () {
@@ -66,5 +95,12 @@ describe('primitive guards', function () {
 			assertGuards(false)(primitive.isNull, undefined);
 			assertGuards(false)(primitive.isNull, {});
 		});
+		it('is fast', function () {
+			assertBenchGuard(
+				primitive.isNull,
+				() => null,
+				(): unknown => true,
+			);
+		}).timeout(30_000);
 	});
 });


### PR DESCRIPTION
Throwing `Error`s to report things is a huge performance sink when we hit an invalid object, esp. when the caller only cares about valid or not.

Two major items:
1. Don't accumulate errors or confirmations unless the caller wants them
2. Don't `new` up `Error` objects because this is outrageously expensive

This has BREAKING CHANGES because it alters the signature of `Checker` and slightly that of `ReasonGuard`