### PR TITLE
feat: record guards

### DIFF
--- a/src/recordGuards.ts
+++ b/src/recordGuards.ts
@@ -1,0 +1,90 @@
+import { pushContext } from './Checker';
+import { thenGuard } from './Combinators';
+import { CompositeError, ContextError } from './ContextError';
+import { ErrorLike, ReasonGuard } from './ReasonGuard';
+import { isObject } from './primitiveGuards';
+
+// Record guards are designed for objects with free-form (e.g. indexer) keys
+// with a common type, vs. object guards where there are specific keys
+// (properties) with individual types
+
+function checkRecord<K extends symbol | string, V>(
+	keyChecker: ReasonGuard<symbol | string, K>,
+	valueChecker: ReasonGuard<unknown, V>,
+	input: object,
+	output?: ErrorLike[],
+	confirmations?: string[],
+	context?: PropertyKey[],
+): input is Record<K, V> {
+	let anyFailed = false;
+	function checkProperty(k: string | symbol) {
+		const keyErrors: ErrorLike[] = [];
+		const keyConfirmations: string[] = [];
+		const innerContext = pushContext(String(k), context);
+		if (!keyChecker(k, keyErrors, keyConfirmations, innerContext)) {
+			anyFailed = true;
+			if (output) {
+				output.push(
+					new CompositeError(
+						keyErrors.map(
+							(err) =>
+								new ContextError(
+									`key ${String(k)}: ${err.message}`,
+									err instanceof ContextError ? err.context : innerContext,
+								),
+						),
+					),
+				);
+			}
+		} else if (confirmations) {
+			confirmations.push(...keyConfirmations.map((c) => `key ${String(k)}: ${c}`));
+		}
+		const valueErrors: ErrorLike[] = [];
+		const valueConfirmations: string[] = [];
+		// have to cast to any here because we're using object as a placeholder for
+		// what might more strictly be `Readonly<Record<string|symbol, unknown>>`,
+		// esp. since we are still checking values even if the key checker failed
+		if (!valueChecker((input as any)[k], valueErrors, valueConfirmations, innerContext)) {
+			anyFailed = true;
+			if (output) {
+				output.push(
+					new CompositeError(
+						valueErrors.map(
+							(err) =>
+								new ContextError(
+									`value ${String(k)}: ${err.message}`,
+									err instanceof ContextError ? err.context : innerContext,
+								),
+						),
+					),
+				);
+			}
+		} else if (confirmations) {
+			confirmations.push(...valueConfirmations.map((c) => `value ${String(k)}: ${c}`));
+		}
+	}
+	// Object.entries would be nice here, but it doesn't give us symbols
+	Object.getOwnPropertyNames(input).forEach(checkProperty);
+	// repeat!
+	Object.getOwnPropertySymbols(input).forEach(checkProperty);
+
+	// unlike an object guard, we don't care if there are no properties, so we
+	// don't track or check `anyPassed` here
+
+	return !anyFailed;
+}
+
+export function objectIsRecord<K extends symbol | string, V>(
+	keyChecker: ReasonGuard<symbol | string, K>,
+	valueChecker: ReasonGuard<unknown, V>,
+): ReasonGuard<object, Record<K, V>> {
+	return (input, output, confirmations, context = []): input is Record<K, V> =>
+		checkRecord(keyChecker, valueChecker, input, output, confirmations, context);
+}
+
+export function isRecord<K extends symbol | string, V>(
+	keyChecker: ReasonGuard<symbol | string, K>,
+	valueChecker: ReasonGuard<unknown, V>,
+): ReasonGuard<unknown, Record<K, V>> {
+	return thenGuard(isObject, objectIsRecord(keyChecker, valueChecker));
+}

--- a/src/recordGuards.ts
+++ b/src/recordGuards.ts
@@ -1,6 +1,6 @@
 import { pushContext } from './Checker';
 import { thenGuard } from './Combinators';
-import { CompositeError, ContextError } from './ContextError';
+import { ContextError } from './ContextError';
 import { ErrorLike, ReasonGuard } from './ReasonGuard';
 import { isObject } from './primitiveGuards';
 
@@ -23,21 +23,17 @@ function checkRecord<K extends symbol | string, V>(
 		const innerContext = pushContext(String(k), context);
 		if (!keyChecker(k, keyErrors, keyConfirmations, innerContext)) {
 			anyFailed = true;
-			if (output) {
-				output.push(
-					new CompositeError(
-						keyErrors.map(
-							(err) =>
-								new ContextError(
-									`key ${String(k)}: ${err.message}`,
-									err instanceof ContextError ? err.context : innerContext,
-								),
+			output?.push(
+				...keyErrors.map(
+					(err) =>
+						new ContextError(
+							`key ${String(k)}: ${err.message}`,
+							err instanceof ContextError ? err.context : innerContext,
 						),
-					),
-				);
-			}
-		} else if (confirmations) {
-			confirmations.push(...keyConfirmations.map((c) => `key ${String(k)}: ${c}`));
+				),
+			);
+		} else {
+			confirmations?.push(...keyConfirmations.map((c) => `key ${String(k)}: ${c}`));
 		}
 		const valueErrors: ErrorLike[] = [];
 		const valueConfirmations: string[] = [];
@@ -46,21 +42,17 @@ function checkRecord<K extends symbol | string, V>(
 		// esp. since we are still checking values even if the key checker failed
 		if (!valueChecker((input as any)[k], valueErrors, valueConfirmations, innerContext)) {
 			anyFailed = true;
-			if (output) {
-				output.push(
-					new CompositeError(
-						valueErrors.map(
-							(err) =>
-								new ContextError(
-									`value ${String(k)}: ${err.message}`,
-									err instanceof ContextError ? err.context : innerContext,
-								),
+			output?.push(
+				...valueErrors.map(
+					(err) =>
+						new ContextError(
+							`value ${String(k)}: ${err.message}`,
+							err instanceof ContextError ? err.context : innerContext,
 						),
-					),
-				);
-			}
-		} else if (confirmations) {
-			confirmations.push(...valueConfirmations.map((c) => `value ${String(k)}: ${c}`));
+				),
+			);
+		} else {
+			confirmations?.push(...valueConfirmations.map((c) => `value ${String(k)}: ${c}`));
 		}
 	}
 	// Object.entries would be nice here, but it doesn't give us symbols

--- a/test/recordGuards.spec.ts
+++ b/test/recordGuards.spec.ts
@@ -1,0 +1,72 @@
+import { assert } from 'chai';
+
+import { ErrorLike, isBoolean, isNumberString, isString, thenGuard } from '../src';
+import { isRecord } from '../src/recordGuards';
+import { assertGuards } from './assertGuards';
+
+const trueGuard = (_: unknown): _ is unknown => true;
+
+describe(isRecord.name, function () {
+	context('key checks', function () {
+		const keyGuard = thenGuard(isString, isNumberString);
+		const guard = isRecord(keyGuard, trueGuard);
+
+		it('reports bad keys', function () {
+			assertGuards(false)(guard, { foo: true });
+			assertGuards(false)(guard, { '12': true, foo: true });
+			// this symbol would be valid if it was stringified
+			assertGuards(false)(guard, { [Symbol('12')]: true });
+		});
+
+		it('accepts good keys', function () {
+			assertGuards(true)(guard, { '12': true });
+		});
+
+		it('reports bad key errors with correct context', function () {
+			const errors: ErrorLike[] = [];
+			guard({ foo: true }, errors);
+			assert.lengthOf(errors, 1);
+			assert.include(JSON.stringify(errors[0]), 'key foo: is not ');
+		});
+
+		it('confirms good keys with correct context', function () {
+			const confirmations: string[] = [];
+			guard({ '12': true }, undefined, confirmations);
+			// two confirms from isObject, two from the key
+			assert.lengthOf(confirmations, 4);
+			for (const c of confirmations.slice(2)) {
+				assert.include(c, 'key 12: ');
+			}
+		});
+	});
+
+	context('value checks', function () {
+		const guard = isRecord(isString, isBoolean);
+
+		it('reports bad values', function () {
+			assertGuards(false)(guard, { foo: 0 });
+			assertGuards(false)(guard, { foo: 0, bar: true });
+		});
+
+		it('accepts good values', function () {
+			assertGuards(true)(guard, { bar: true });
+		});
+
+		it('reports bad value errors with correct context', function () {
+			const errors: ErrorLike[] = [];
+			guard({ foo: 0 }, errors);
+			assert.lengthOf(errors, 1);
+			assert.include(JSON.stringify(errors[0]), 'value foo: not ');
+		});
+
+		it('confirms good values with correct context', function () {
+			const confirmations: string[] = [];
+			guard({ foo: true }, undefined, confirmations);
+			// two confirms from isObject, one from the key, one from the value
+			assert.lengthOf(confirmations, 4);
+			for (const c of confirmations.slice(3)) {
+				assert.include(c, 'value foo: ');
+			}
+		});
+	});
+});

--- a/test/recordGuards.spec.ts
+++ b/test/recordGuards.spec.ts
@@ -69,4 +69,16 @@ describe(isRecord.name, function () {
 			}
 		});
 	});
+
+	context('nesting', function () {
+		const innerGuard = isRecord(isString, isBoolean);
+		const outerGuard = isRecord(isString, innerGuard);
+
+		it('provides correct nested error context', function () {
+			const errors: ErrorLike[] = [];
+			outerGuard({ foo: { bar: 0 } }, errors);
+			assert.lengthOf(errors, 1);
+			assert.include(JSON.stringify(errors[0]), 'value foo: value bar: not ');
+		});
+	});
 });


### PR DESCRIPTION
Where object guards are intended for values with properties of various
types, record guards are intended for things like `Record<K, V>` or
`{[k: K]: V}`
